### PR TITLE
[RPA-909] Adds new excel action: Insert columns after

### DIFF
--- a/runbotics-orchestrator/build.gradle
+++ b/runbotics-orchestrator/build.gradle
@@ -26,7 +26,7 @@ plugins {
 
 group = "com.runbotics"
 
-version = "2.8.0-SNAPSHOT.24"
+version = "2.8.0-SNAPSHOT.25"
 
 description = ""
 

--- a/runbotics-orchestrator/package.json
+++ b/runbotics-orchestrator/package.json
@@ -1,6 +1,6 @@
 {
     "name": "runbotics",
-    "version": "2.8.0-SNAPSHOT.24",
+    "version": "2.8.0-SNAPSHOT.25",
     "private": true,
     "description": "Description for runbotics",
     "license": "UNLICENSED",

--- a/runbotics/common/config/runbotics.json
+++ b/runbotics/common/config/runbotics.json
@@ -1,3 +1,3 @@
 {
-    "version": "2.8.0-SNAPSHOT.24"
+    "version": "2.8.0-SNAPSHOT.25"
 }

--- a/runbotics/runbotics-actions-windows/src/automation/office/excel.action-handler.ts
+++ b/runbotics/runbotics-actions-windows/src/automation/office/excel.action-handler.ts
@@ -27,9 +27,7 @@ export default class ExcelActionHandler extends StatefulActionHandler {
 
     async open(input: ExcelOpenActionInput): Promise<void> {
         const winax = await import('winax');
-        this.session = new winax.Object('Excel.Application', {
-            activate: true,
-        });
+        this.session = new winax.Object('Excel.Application', { activate: true });
         this.session.Workbooks.Open(input.path);
         this.session.Visible = true;
         if (input.worksheet) {
@@ -55,7 +53,9 @@ export default class ExcelActionHandler extends StatefulActionHandler {
         this.session = null;
     }
 
-    async save(input: ExcelSaveActionInput) {
+    async save(
+        input: ExcelSaveActionInput
+    ) {
         if (input.fileName) {
             this.session.ActiveWorkbook.SaveAs(input.fileName);
         } else {
@@ -63,14 +63,18 @@ export default class ExcelActionHandler extends StatefulActionHandler {
         }
     }
 
-    async getCell(input: ExcelGetCellActionInput): Promise<unknown> {
+    async getCell(
+        input: ExcelGetCellActionInput
+    ): Promise<unknown> {
         return this.session
             .Worksheets(input?.worksheet ?? this.session.ActiveSheet.Name)
             .Range(`${input.column}${input.row}`)
-            .Value();
+            .Value()
     }
 
-    async getCells(input: ExcelGetCellsActionInput): Promise<unknown[][]> {
+    async getCells(
+        input: ExcelGetCellsActionInput
+    ): Promise<unknown[][]> {
         try {
             const cellValues: unknown[][] = [];
             const targetWorksheet = this.session.Worksheets(input?.worksheet ?? this.session.ActiveSheet.Name);
@@ -78,7 +82,7 @@ export default class ExcelActionHandler extends StatefulActionHandler {
                 startColumn: input?.startColumn,
                 startRow: input?.startRow ? Number(input?.startRow) : 1,
                 endColumn: input.endColumn,
-                endRow: Number(input.endRow),
+                endRow: Number(input.endRow)
             });
 
             for (let rowIdx = startRow; rowIdx <= endRow; rowIdx++) {
@@ -95,17 +99,21 @@ export default class ExcelActionHandler extends StatefulActionHandler {
         }
     }
 
-    async setCell(input: ExcelSetCellActionInput): Promise<void> {
+    async setCell(
+        input: ExcelSetCellActionInput
+    ): Promise<void> {
         const cell = this.session.Worksheets(input?.worksheet ?? this.session.ActiveSheet.Name).Range(`${input.column}${input.row}`);
 
         cell.Value = input.value;
     }
 
-    async setCells(input: ExcelSetCellsActionInput): Promise<void> {
+    async setCells(
+        input: ExcelSetCellsActionInput
+    ): Promise<void> {
         if (!Array.isArray(input.cellValues)) throw new Error(ExcelErrorMessage.setCellsIncorrectInput());
         const { startRow, startColumn } = this.getCellCoordinates({
             startColumn: input?.startColumn,
-            startRow: Number(input?.startRow ?? 1),
+            startRow: Number(input?.startRow ?? 1)
         });
         let columnCounter = startColumn,
             rowCounter = startRow;
@@ -124,10 +132,12 @@ export default class ExcelActionHandler extends StatefulActionHandler {
         }
     }
 
-    async findFirstEmptyRow(input: ExcelFindFirstEmptyRowActionInput): Promise<number> {
+    async findFirstEmptyRow(
+        input: ExcelFindFirstEmptyRowActionInput
+    ): Promise<number> {
         const { startColumn, startRow } = this.getCellCoordinates({
             startColumn: input?.startColumn,
-            startRow: Number(input?.startRow ?? 1),
+            startRow: Number(input?.startRow ?? 1)
         });
         let rowCounter = startRow;
         while (
@@ -135,12 +145,13 @@ export default class ExcelActionHandler extends StatefulActionHandler {
                 .Worksheets(input?.worksheet ?? this.session.ActiveSheet.Name)
                 .Cells(rowCounter, startColumn)
                 .Value()
-        )
-            rowCounter++;
+        ) rowCounter++;
         return rowCounter;
     }
 
-    async deleteColumns(input: ExcelDeleteColumnsActionInput): Promise<void> {
+    async deleteColumns(
+        input: ExcelDeleteColumnsActionInput
+    ): Promise<void> {
         try {
             const targetWorksheet = this.session.Worksheets(input?.worksheet ?? this.session.ActiveSheet.Name);
             if (!Array.isArray(input.columnRange)) targetWorksheet.Columns(input.columnRange).Delete();
@@ -156,27 +167,39 @@ export default class ExcelActionHandler extends StatefulActionHandler {
         }
     }
 
-    async insertColumnsBefore(input: ExcelInsertColumnsActionInput): Promise<void> {
+    async insertColumnsBefore(
+        input: ExcelInsertColumnsActionInput
+    ): Promise<void> {
         const targetWorksheet = this.session.Worksheets(input?.worksheet ?? this.session.ActiveSheet.Name);
 
         try {
             const column = this.getColumnCoordinate(input.column);
             const amount = input.amount;
 
-            targetWorksheet.Range(targetWorksheet.Columns(column), targetWorksheet.Columns(column + amount - 1)).Insert();
+            targetWorksheet
+                .Range(
+                    targetWorksheet.Columns(column), 
+                    targetWorksheet.Columns(column + amount - 1))
+                .Insert();
         } catch (e) {
             throw new Error(ExcelErrorMessage.insertColumnsIncorrectInput(e));
         }
     }
 
-    async insertColumnsAfter(input: ExcelInsertColumnsActionInput): Promise<void> {
+    async insertColumnsAfter(
+        input: ExcelInsertColumnsActionInput
+    ): Promise<void> {
         const targetWorksheet = this.session.Worksheets(input?.worksheet ?? this.session.ActiveSheet.Name);
 
         try {
             const column = this.getColumnCoordinate(input.column);
             const amount = input.amount;
 
-            targetWorksheet.Range(targetWorksheet.Columns(column + 1), targetWorksheet.Columns(column + amount)).Insert();
+            targetWorksheet
+                .Range(
+                    targetWorksheet.Columns(column + 1),
+                    targetWorksheet.Columns(column + amount))
+                .Insert();
         } catch (e) {
             throw new Error(ExcelErrorMessage.insertColumnsIncorrectInput(e));
         }
@@ -188,17 +211,26 @@ export default class ExcelActionHandler extends StatefulActionHandler {
         }
     }
 
-    async clearCells(input: ExcelClearCellsActionInput): Promise<void> {
+    async clearCells(
+        input: ExcelClearCellsActionInput
+    ): Promise<void> {
         try {
             const targetWorksheet = this.session.Worksheets(input?.worksheet ?? this.session.ActiveSheet.Name);
-            if (!Array.isArray(input.targetCells)) targetWorksheet.Range(input.targetCells).Clear();
-            else for (const cellCoordinate of input.targetCells) targetWorksheet.Range(cellCoordinate).Clear();
+            if (!Array.isArray(input.targetCells)) 
+                targetWorksheet
+                    .Range(input.targetCells)
+                    .Clear();
+            else for (const cellCoordinate of input.targetCells)
+                targetWorksheet.Range(cellCoordinate)
+                    .Clear();
         } catch (e) {
             throw new Error(ExcelErrorMessage.clearCellsIncorrectInput(e));
         }
     }
 
-    run(request: ExcelActionRequest) {
+    run(
+        request: ExcelActionRequest
+    ) {
         if (process.platform !== 'win32') {
             throw new Error('Excel actions can be run only on Windows bot');
         }
@@ -250,7 +282,7 @@ export default class ExcelActionHandler extends StatefulActionHandler {
                 startColumn: startColumn ? this.getColumnCoordinate(startColumn) : 1,
                 startRow: startRow ?? 1,
                 endColumn: this.getColumnCoordinate(endColumn),
-                endRow: endRow ?? null,
+                endRow: endRow ?? null
             };
         } catch (e) {
             throw new Error(ExcelErrorMessage.cellCoordinatesIncorrectInput(e));

--- a/runbotics/runbotics-actions-windows/src/automation/office/excel.action-handler.ts
+++ b/runbotics/runbotics-actions-windows/src/automation/office/excel.action-handler.ts
@@ -186,7 +186,8 @@ export default class ExcelActionHandler extends StatefulActionHandler {
             targetWorksheet
                 .Range(
                     targetWorksheet.Columns(column), 
-                    targetWorksheet.Columns(column + amount - 1))
+                    targetWorksheet.Columns(column + amount - 1)
+                )
                 .Insert();
         } catch (e) {
             throw new Error(ExcelErrorMessage.insertColumnsIncorrectInput(e));

--- a/runbotics/runbotics-actions-windows/src/automation/office/excel.action-handler.ts
+++ b/runbotics/runbotics-actions-windows/src/automation/office/excel.action-handler.ts
@@ -91,8 +91,9 @@ export default class ExcelActionHandler extends StatefulActionHandler {
                     rowValues.push(
                         targetWorksheet
                             .Cells(rowIdx, columnIdx)
-                            .Value() ?? '')
-                };
+                            .Value() ?? ''
+                    );
+                }
                 cellValues.push(rowValues);
             }
 
@@ -115,7 +116,7 @@ export default class ExcelActionHandler extends StatefulActionHandler {
     async setCells(
         input: ExcelSetCellsActionInput
     ): Promise<void> {
-        if (!Array.isArray(input.cellValues)) 
+        if (!Array.isArray(input.cellValues))
             throw new Error(ExcelErrorMessage.setCellsIncorrectInput());
         const { startRow, startColumn } = this.getCellCoordinates({
             startColumn: input?.startColumn,

--- a/runbotics/runbotics-actions-windows/src/automation/office/excel.action-handler.ts
+++ b/runbotics/runbotics-actions-windows/src/automation/office/excel.action-handler.ts
@@ -88,8 +88,11 @@ export default class ExcelActionHandler extends StatefulActionHandler {
             for (let rowIdx = startRow; rowIdx <= endRow; rowIdx++) {
                 const rowValues: unknown[] = [];
                 for (let columnIdx = startColumn; columnIdx <= endColumn; columnIdx++) {
-                    rowValues.push(targetWorksheet.Cells(rowIdx, columnIdx).Value() ?? '');
-                }
+                    rowValues.push(
+                        targetWorksheet
+                            .Cells(rowIdx, columnIdx)
+                            .Value() ?? '')
+                };
                 cellValues.push(rowValues);
             }
 
@@ -102,7 +105,9 @@ export default class ExcelActionHandler extends StatefulActionHandler {
     async setCell(
         input: ExcelSetCellActionInput
     ): Promise<void> {
-        const cell = this.session.Worksheets(input?.worksheet ?? this.session.ActiveSheet.Name).Range(`${input.column}${input.row}`);
+        const cell = this.session
+            .Worksheets(input?.worksheet ?? this.session.ActiveSheet.Name)
+            .Range(`${input.column}${input.row}`)
 
         cell.Value = input.value;
     }
@@ -110,7 +115,8 @@ export default class ExcelActionHandler extends StatefulActionHandler {
     async setCells(
         input: ExcelSetCellsActionInput
     ): Promise<void> {
-        if (!Array.isArray(input.cellValues)) throw new Error(ExcelErrorMessage.setCellsIncorrectInput());
+        if (!Array.isArray(input.cellValues)) 
+            throw new Error(ExcelErrorMessage.setCellsIncorrectInput());
         const { startRow, startColumn } = this.getCellCoordinates({
             startColumn: input?.startColumn,
             startRow: Number(input?.startRow ?? 1)
@@ -126,7 +132,7 @@ export default class ExcelActionHandler extends StatefulActionHandler {
                 } catch (e) {
                     throw new Error(ExcelErrorMessage.setCellsIncorrectInput(e));
                 }
-            }
+            } 
             rowCounter++;
             columnCounter = startColumn;
         }
@@ -216,21 +222,20 @@ export default class ExcelActionHandler extends StatefulActionHandler {
     ): Promise<void> {
         try {
             const targetWorksheet = this.session.Worksheets(input?.worksheet ?? this.session.ActiveSheet.Name);
-            if (!Array.isArray(input.targetCells)) 
+            if (!Array.isArray(input.targetCells))
                 targetWorksheet
                     .Range(input.targetCells)
                     .Clear();
             else for (const cellCoordinate of input.targetCells)
-                targetWorksheet.Range(cellCoordinate)
+                targetWorksheet
+                    .Range(cellCoordinate)
                     .Clear();
         } catch (e) {
             throw new Error(ExcelErrorMessage.clearCellsIncorrectInput(e));
         }
     }
 
-    run(
-        request: ExcelActionRequest
-    ) {
+    run(request: ExcelActionRequest) {
         if (process.platform !== 'win32') {
             throw new Error('Excel actions can be run only on Windows bot');
         }

--- a/runbotics/runbotics-actions-windows/src/automation/office/excel.types.ts
+++ b/runbotics/runbotics-actions-windows/src/automation/office/excel.types.ts
@@ -11,7 +11,8 @@ export type ExcelActionRequest =
     | DesktopRunRequest<"excel.findFirstEmptyRow", ExcelFindFirstEmptyRowActionInput>
     | DesktopRunRequest<"excel.clearCells", ExcelClearCellsActionInput>
     | DesktopRunRequest<"excel.deleteColumns", ExcelDeleteColumnsActionInput> 
-    | DesktopRunRequest<"excel.insertColumnsBefore", ExcelInsertColumnsActionInput>;
+    | DesktopRunRequest<"excel.insertColumnsBefore", ExcelInsertColumnsActionInput>
+    | DesktopRunRequest<"excel.insertColumnsAfter", ExcelInsertColumnsActionInput>;
 
 export interface ExcelOpenActionInput {
     path: string;

--- a/runbotics/runbotics-common/src/actions/actions.ts
+++ b/runbotics/runbotics-common/src/actions/actions.ts
@@ -165,6 +165,7 @@ export enum ExcelAction {
 	FIND_FIRST_EMPTY_ROW = 'excel.findFirstEmptyRow',
 	DELETE_COLUMNS = 'excel.deleteColumns',
 	INSERT_COLUMNS_BEFORE = "excel.insertColumnsBefore",
+	INSERT_COLUMNS_AFTER = "excel.insertColumnsAfter",
 	SAVE = 'excel.save',
 	CLOSE = 'excel.close',
 }

--- a/runbotics/runbotics-desktop/package.json
+++ b/runbotics/runbotics-desktop/package.json
@@ -1,6 +1,6 @@
 {
     "name": "runbotics-desktop",
-    "version": "2.8.0-SNAPSHOT.24",
+    "version": "2.8.0-SNAPSHOT.25",
     "author": {
         "name": "runbotics",
         "email": "contact@runbotics.com"

--- a/runbotics/runbotics-orchestrator-ui/package.json
+++ b/runbotics/runbotics-orchestrator-ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "runbotics-orchestrator-ui",
-    "version": "2.8.0-SNAPSHOT.24",
+    "version": "2.8.0-SNAPSHOT.25",
     "author": {
         "name": "runbotics",
         "email": "contact@runbotics.com"

--- a/runbotics/runbotics-orchestrator-ui/src/src-app/Actions/excel.actions.ts
+++ b/runbotics/runbotics-orchestrator-ui/src/src-app/Actions/excel.actions.ts
@@ -530,6 +530,60 @@ const getExcelActions: () => Record<string, IBpmnAction> = () => ({
             formData: {},
         },
     },
+    'excel.insertColumnsAfter': {
+        id: ExcelAction.INSERT_COLUMNS_AFTER,
+        label: translate('Process.Details.Modeler.Actions.Excel.InsertColumnsAfter.Label'),
+        script: ExcelAction.INSERT_COLUMNS_AFTER,
+        runner: Runner.DESKTOP_SCRIPT,
+        system: ActionSystem.WINDOWS,
+        form: {
+            schema: {
+                type: 'object',
+                properties: {
+                    input: {
+                        title: translate('Process.Details.Modeler.Actions.Common.Input'),
+                        type: 'object',
+                        properties: {
+                            column: {
+                                title: translate('Process.Details.Modeler.Actions.Excel.StartColumn'),
+                                type: 'string',
+                            },
+                            amount: {
+                                title: translate('Process.Details.Modeler.Actions.Excel.InsertColumns.ColumnsAmount'),
+                                type: 'number',
+                            },
+                            worksheet: {
+                                title: translate('Process.Details.Modeler.Actions.Excel.Worksheet'),
+                                type: 'string',
+                            },
+                        },
+                        required: ['column', 'amount'],
+                    },
+                },
+            },
+            uiSchema: {
+                'ui:order': ['input'],
+                input: {
+                    column: {
+                        'ui:options': {
+                            info: translate('Process.Details.Modeler.Actions.Excel.InsertColumns.Column.Info'),
+                        },
+                    },
+                    amount: {
+                        'ui:options': {
+                            info: translate('Process.Details.Modeler.Actions.Excel.InsertColumns.Amount.Info'),
+                        },
+                    },
+                    worksheet: {
+                        'ui:options': {
+                            info: translate('Process.Details.Modeler.Actions.Excel.Worksheet.Info'),
+                        },
+                    },
+                },
+            },
+            formData: {},
+        },
+    },
     'excel.save': {
         id: ExcelAction.SAVE,
         label: translate('Process.Details.Modeler.Actions.Excel.Save.Label'),

--- a/runbotics/runbotics-orchestrator-ui/src/src-app/translations/en/process/actions/excel.ts
+++ b/runbotics/runbotics-orchestrator-ui/src/src-app/translations/en/process/actions/excel.ts
@@ -28,6 +28,7 @@ const excelActionsTranslations = {
     'Process.Details.Modeler.Actions.Excel.DeleteColumns.ColumnRange': 'Column range',
     'Process.Details.Modeler.Actions.Excel.DeleteColumns.ColumnRange.Info': 'Column, column range or array e.g. "G", "C:F" or ["C", "E", "H"].',
     'Process.Details.Modeler.Actions.Excel.InsertColumnsBefore.Label': 'Insert columns before',
+    'Process.Details.Modeler.Actions.Excel.InsertColumnsAfter.Label': 'Insert columns after',
     'Process.Details.Modeler.Actions.Excel.InsertColumns.ColumnsAmount': 'Amount of columns',
     'Process.Details.Modeler.Actions.Excel.InsertColumns.Column.Info': 'Column letter or number, e.g. "AZ" or 25.',
     'Process.Details.Modeler.Actions.Excel.InsertColumns.Amount.Info': 'Number of columns to insert.',

--- a/runbotics/runbotics-orchestrator-ui/src/src-app/translations/pl/process/actions/excel.ts
+++ b/runbotics/runbotics-orchestrator-ui/src/src-app/translations/pl/process/actions/excel.ts
@@ -30,6 +30,7 @@ const excelActionsTranslations: typeof englishExcelActionsTranslations = {
     'Process.Details.Modeler.Actions.Excel.DeleteColumns.ColumnRange': 'Zasięg kolumn',
     'Process.Details.Modeler.Actions.Excel.DeleteColumns.ColumnRange.Info': 'Kolumna, przedział lub lista np. "G", "C:F" lub ["C", "E", "H"].',
     'Process.Details.Modeler.Actions.Excel.InsertColumnsBefore.Label': 'Wstaw kolumny przed',
+    'Process.Details.Modeler.Actions.Excel.InsertColumnsAfter.Label': 'Wstaw kolumny po',
     'Process.Details.Modeler.Actions.Excel.InsertColumns.ColumnsAmount': 'Liczba kolumn',
     'Process.Details.Modeler.Actions.Excel.InsertColumns.Column.Info': 'Oznaczenie literowe lub numer kolumny, np "AZ" lub 25.',
     'Process.Details.Modeler.Actions.Excel.InsertColumns.Amount.Info': 'Liczba kolumn do wstawienia.',

--- a/runbotics/runbotics-scheduler/package.json
+++ b/runbotics/runbotics-scheduler/package.json
@@ -1,6 +1,6 @@
 {
     "name": "runbotics-scheduler",
-    "version": "2.8.0-SNAPSHOT.24",
+    "version": "2.8.0-SNAPSHOT.25",
     "author": {
         "name": "runbotics",
         "email": "contact@runbotics.com"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above (if possible start with issue number with # prefix) -->
<!--- Example: #123 - Some description -->

## Description

Allows user to add specified number of columns after given column (by letter or number).

### Example scenario #1:
Inputs:
![image](https://github.com/runbotics/runbotics/assets/61866178/49f19a49-ec3e-4379-a250-15fb280cb641)

Outcome:
![image](https://github.com/runbotics/runbotics/assets/61866178/2039aed3-9632-487c-bde7-7c91d2673d97)

### Example scenario #2
Inputs:
![image](https://github.com/runbotics/runbotics/assets/61866178/7f3206c3-5eca-4ac0-bb13-da8956e1c11a)

Outcome:
![image](https://github.com/runbotics/runbotics/assets/61866178/7637e12b-f8df-4be2-a927-6c025127a51c)

### Error handling:
- column input is negative number
- amount is negative number

![image](https://github.com/runbotics/runbotics/assets/61866178/66f89c00-6ac3-43a7-8eff-f85984281d79)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

---

I agree to the terms of the RunBotics Contributor License Agreement.