### PR TITLE
[RPA-953] Fixes pagination issue in the bots collections tab

### DIFF
--- a/runbotics-orchestrator/build.gradle
+++ b/runbotics-orchestrator/build.gradle
@@ -26,7 +26,7 @@ plugins {
 
 group = "com.runbotics"
 
-version = "2.8.0-SNAPSHOT.50"
+version = "2.8.0-SNAPSHOT.51"
 
 description = ""
 

--- a/runbotics/common/config/runbotics.json
+++ b/runbotics/common/config/runbotics.json
@@ -1,3 +1,3 @@
 {
-    "version": "2.8.0-SNAPSHOT.50"
+    "version": "2.8.0-SNAPSHOT.51"
 }

--- a/runbotics/runbotics-desktop/package.json
+++ b/runbotics/runbotics-desktop/package.json
@@ -1,6 +1,6 @@
 {
     "name": "runbotics-desktop",
-    "version": "2.8.0-SNAPSHOT.50",
+    "version": "2.8.0-SNAPSHOT.51",
     "author": {
         "name": "runbotics",
         "email": "contact@runbotics.com"

--- a/runbotics/runbotics-orchestrator-ui/package.json
+++ b/runbotics/runbotics-orchestrator-ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "runbotics-orchestrator-ui",
-    "version": "2.8.0-SNAPSHOT.50",
+    "version": "2.8.0-SNAPSHOT.51",
     "author": {
         "name": "runbotics",
         "email": "contact@runbotics.com"

--- a/runbotics/runbotics-orchestrator-ui/src/src-app/views/bot/BotCollectionView/BotCollectionView.tsx
+++ b/runbotics/runbotics-orchestrator-ui/src/src-app/views/bot/BotCollectionView/BotCollectionView.tsx
@@ -27,9 +27,9 @@ const BotCollectionView: VFC = () => {
 
     const router = useRouter();
     const query = useQuery();
-    const currentPage = parseInt(query.get('page'), 10);
+    const pageFromUrl = query.get('page');
     const pageSizeFromUrl = query.get('pageSize');
-    const [page, setPage] = useState(currentPage);
+    const [page, setPage] = useState(pageFromUrl ? parseInt(pageFromUrl) : 0);
     const [limit, setLimit] = useState(
         pageSizeFromUrl ? parseInt(pageSizeFromUrl, 10) : getLimitByDisplayMode(displayMode),
     );
@@ -48,7 +48,7 @@ const BotCollectionView: VFC = () => {
 
     useEffect(() => {
         const params = getBotCollectionPageParams(page, limit, debouncedSearch, searchField);
-        router.replace({ pathname: router.pathname, query: { page: 0, pageSize: limit, search, searchField } });
+        router.replace({ pathname: router.pathname, query: { page, pageSize: limit, search, searchField } });
 
         dispatch(botCollectionActions.getByPage(params));
         // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/runbotics/runbotics-scheduler/package.json
+++ b/runbotics/runbotics-scheduler/package.json
@@ -1,6 +1,6 @@
 {
     "name": "runbotics-scheduler",
-    "version": "2.8.0-SNAPSHOT.50",
+    "version": "2.8.0-SNAPSHOT.51",
     "author": {
         "name": "runbotics",
         "email": "contact@runbotics.com"


### PR DESCRIPTION
## Description
Previously: once entering the "COLLECTIONS" page the next and previous button was always enabled for the user to click even though only there were only one page available. It was caused by the fact, that page number was NaN. It also caused that hitting next/previous page displayed in the url as page=NaN. Page numeration starts at 0 (same is in the Processes pagination), so I left it as it was.

First tab enter (both arrows enabled even though we are on the first page):
![image](https://github.com/runbotics/runbotics/assets/61866178/b0cac941-438b-4c57-b243-c74731260d67)
![image](https://github.com/runbotics/runbotics/assets/61866178/cc410094-92d7-44f8-96c7-b93fbf117f61)

After clicking previous/next arrow (both arrows enabled even though we are on the last page):
![image](https://github.com/runbotics/runbotics/assets/61866178/c7aaee4f-6926-4203-9e81-f6b9e164071d)
![image](https://github.com/runbotics/runbotics/assets/61866178/06b0d560-3001-4812-a80d-21c16d3d0b46)

Now:
Once we enter the "COLLECTIONS" tab correct page is being used. Previous page is disabled (since we are on the first available page) and once we click next page is no more NaN.

First tab enter (previous arrow not available):
![image](https://github.com/runbotics/runbotics/assets/61866178/6ffa18fe-beab-487c-9a1c-19168321e06a)
![image](https://github.com/runbotics/runbotics/assets/61866178/a4c0a4fe-2329-40b3-bf7f-01d3428c4da4)

After going to the next page (previous arrow available, next disabled since it is a last page)
![image](https://github.com/runbotics/runbotics/assets/61866178/51eaaf7e-dfe7-4bc6-8f04-9a7c8ec326b4)
![image](https://github.com/runbotics/runbotics/assets/61866178/423fa762-6b04-4cfd-8360-bf9cad01d41e)


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

---

I agree to the terms of the RunBotics Contributor License Agreement.