### PR TITLE
[feature/RPA-949] Block editing/deleting global variables for users other than admin and owner

### DIFF
--- a/runbotics-orchestrator/build.gradle
+++ b/runbotics-orchestrator/build.gradle
@@ -26,7 +26,7 @@ plugins {
 
 group = "com.runbotics"
 
-version = "2.8.0-SNAPSHOT.61"
+version = "2.8.0-SNAPSHOT.62"
 
 description = ""
 

--- a/runbotics-orchestrator/src/main/java/com/runbotics/domain/GlobalVariable.java
+++ b/runbotics-orchestrator/src/main/java/com/runbotics/domain/GlobalVariable.java
@@ -34,6 +34,9 @@ public class GlobalVariable implements Serializable {
     private ZonedDateTime lastModified;
 
     @ManyToOne
+    private User creator;
+
+    @ManyToOne
     private User user;
 
     // jhipster-needle-entity-add-field - JHipster will add fields here
@@ -126,6 +129,14 @@ public class GlobalVariable implements Serializable {
 
     public void setUser(User user) {
         this.user = user;
+    }
+
+    public User getCreator() {
+        return this.creator;
+    }
+
+    public void setCreator(User user) {
+        this.creator = user;
     }
 
     // jhipster-needle-entity-add-getters-setters - JHipster will add getters and setters here

--- a/runbotics-orchestrator/src/main/java/com/runbotics/service/dto/GlobalVariableDTO.java
+++ b/runbotics-orchestrator/src/main/java/com/runbotics/service/dto/GlobalVariableDTO.java
@@ -23,6 +23,8 @@ public class GlobalVariableDTO implements Serializable {
 
     private UserDTO user;
 
+    private UserDTO creator;
+
     public Long getId() {
         return id;
     }
@@ -79,6 +81,14 @@ public class GlobalVariableDTO implements Serializable {
         this.user = user;
     }
 
+    public UserDTO getCreator() {
+        return creator;
+    }
+
+    public void setCreator(UserDTO user) {
+        this.creator = user;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -111,6 +121,7 @@ public class GlobalVariableDTO implements Serializable {
             ", value='" + getValue() + "'" +
             ", lastModified='" + getLastModified() + "'" +
             ", user=" + getUser() +
+            ", creator=" + getCreator() +
             "}";
     }
 }

--- a/runbotics-orchestrator/src/main/java/com/runbotics/service/impl/GlobalVariableServiceImpl.java
+++ b/runbotics-orchestrator/src/main/java/com/runbotics/service/impl/GlobalVariableServiceImpl.java
@@ -46,6 +46,7 @@ public class GlobalVariableServiceImpl implements GlobalVariableService {
         GlobalVariable globalVariable = globalVariableMapper.toEntity(globalVariableDTO);
         globalVariable.setLastModified(ZonedDateTime.now());
         var user = userService.getUserWithAuthorities().get();
+        if ( globalVariableDTO.getId() == null ) globalVariable.setCreator(user);
         globalVariable.setUser(user);
         globalVariable = globalVariableRepository.save(globalVariable);
         return globalVariableMapper.toDto(globalVariable);

--- a/runbotics-orchestrator/src/main/resources/config/liquibase/changelog/20230831151264_changelog.xml
+++ b/runbotics-orchestrator/src/main/resources/config/liquibase/changelog/20230831151264_changelog.xml
@@ -1,0 +1,34 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-4.1.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+    <changeSet author="depcikm" id="20230831151264-1">
+        <preConditions onFail="MARK_RAN">
+            <and>
+                <tableExists tableName="global_variable"/>
+                <not>
+                    <columnExists tableName="global_variable" columnName="creator_id"/>
+                </not>
+                <not>
+                    <foreignKeyConstraintExists foreignKeyName="fk_global_variable_creator_id" foreignKeyTableName="global_variable" />
+                </not>
+            </and>
+        </preConditions>
+        <addColumn tableName="global_variable">
+            <column name="creator_id" type="BIGINT"  />
+        </addColumn>
+        <addForeignKeyConstraint baseTableName="global_variable"
+                                 baseColumnNames="creator_id"
+                                 constraintName="fk_global_variable_creator_id"
+                                 referencedTableName="jhi_user"
+                                 referencedColumnNames="id"
+                                 deferrable="false"
+                                 initiallyDeferred="false"
+                                 validate="true"
+                                 onDelete="SET NULL"
+        />
+        <sql>
+            UPDATE global_variable
+            SET creator_id = user_id
+            WHERE creator_id ISNULL;
+        </sql>
+    </changeSet>
+</databaseChangeLog>

--- a/runbotics-orchestrator/src/main/resources/config/liquibase/changelog/20230831151264_changelog.xml
+++ b/runbotics-orchestrator/src/main/resources/config/liquibase/changelog/20230831151264_changelog.xml
@@ -7,14 +7,27 @@
                 <not>
                     <columnExists tableName="global_variable" columnName="creator_id"/>
                 </not>
-                <not>
-                    <foreignKeyConstraintExists foreignKeyName="fk_global_variable_creator_id" foreignKeyTableName="global_variable" />
-                </not>
             </and>
         </preConditions>
         <addColumn tableName="global_variable">
             <column name="creator_id" type="BIGINT"  />
         </addColumn>
+        <sql>
+            UPDATE global_variable
+            SET creator_id = user_id
+            WHERE creator_id IS NULL;
+        </sql>
+    </changeSet>
+    <changeSet author="depcikm" id="20230831151264-2">
+        <preConditions onFail="MARK_RAN">
+            <and>
+                <tableExists tableName="global_variable"/>
+                <columnExists tableName="global_variable" columnName="creator_id"/>
+                <not>
+                    <foreignKeyConstraintExists foreignKeyName="fk_global_variable_creator_id" foreignKeyTableName="global_variable" />
+                </not>
+            </and>
+        </preConditions>
         <addForeignKeyConstraint baseTableName="global_variable"
                                  baseColumnNames="creator_id"
                                  constraintName="fk_global_variable_creator_id"
@@ -25,10 +38,5 @@
                                  validate="true"
                                  onDelete="SET NULL"
         />
-        <sql>
-            UPDATE global_variable
-            SET creator_id = user_id
-            WHERE creator_id ISNULL;
-        </sql>
     </changeSet>
 </databaseChangeLog>

--- a/runbotics/common/config/runbotics.json
+++ b/runbotics/common/config/runbotics.json
@@ -1,3 +1,3 @@
 {
-    "version": "2.8.0-SNAPSHOT.61"
+    "version": "2.8.0-SNAPSHOT.62"
 }

--- a/runbotics/runbotics-desktop/package.json
+++ b/runbotics/runbotics-desktop/package.json
@@ -1,6 +1,6 @@
 {
     "name": "runbotics-desktop",
-    "version": "2.8.0-SNAPSHOT.61",
+    "version": "2.8.0-SNAPSHOT.62",
     "author": {
         "name": "runbotics",
         "email": "contact@runbotics.com"

--- a/runbotics/runbotics-orchestrator-ui/package.json
+++ b/runbotics/runbotics-orchestrator-ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "runbotics-orchestrator-ui",
-    "version": "2.8.0-SNAPSHOT.61",
+    "version": "2.8.0-SNAPSHOT.62",
     "author": {
         "name": "runbotics",
         "email": "contact@runbotics.com"

--- a/runbotics/runbotics-orchestrator-ui/src/src-app/translations/en/variables.json
+++ b/runbotics/runbotics-orchestrator-ui/src/src-app/translations/en/variables.json
@@ -8,6 +8,7 @@
     "Variables.ListView.Table.Header.Type": "Type",
     "Variables.ListView.Table.Header.LastModified": "Last modified",
     "Variables.ListView.Table.Header.ModifiedBy": "Modified by",
+    "Variables.ListView.Table.Header.CreatedBy": "Created by",
     "Variables.ListView.Table.Actions.Edit": "Edit",
     "Variables.ListView.Table.Actions.Delete": "Delete",
     "Variables.ListView.Action.Delete.Dialog.Title": "Delete global variable",

--- a/runbotics/runbotics-orchestrator-ui/src/src-app/translations/pl/variables.json
+++ b/runbotics/runbotics-orchestrator-ui/src/src-app/translations/pl/variables.json
@@ -8,6 +8,7 @@
     "Variables.ListView.Table.Header.Type": "Rodzaj",
     "Variables.ListView.Table.Header.LastModified": "Ostatnio zmodyfikowany",
     "Variables.ListView.Table.Header.ModifiedBy": "Zmodyfikowany przez",
+    "Variables.ListView.Table.Header.CreatedBy": "Utworzony przez",
     "Variables.ListView.Table.Actions.Edit": "Edytuj",
     "Variables.ListView.Table.Actions.Delete": "Usuń",
     "Variables.ListView.Action.Delete.Dialog.Title": "Usuń zmienną globalną",

--- a/runbotics/runbotics-orchestrator-ui/src/src-app/translations/pl/variables.json
+++ b/runbotics/runbotics-orchestrator-ui/src/src-app/translations/pl/variables.json
@@ -8,7 +8,7 @@
     "Variables.ListView.Table.Header.Type": "Rodzaj",
     "Variables.ListView.Table.Header.LastModified": "Ostatnio zmodyfikowany",
     "Variables.ListView.Table.Header.ModifiedBy": "Zmodyfikowany przez",
-    "Variables.ListView.Table.Header.CreatedBy": "Utworzony przez",
+    "Variables.ListView.Table.Header.CreatedBy": "Twórca",
     "Variables.ListView.Table.Actions.Edit": "Edytuj",
     "Variables.ListView.Table.Actions.Delete": "Usuń",
     "Variables.ListView.Action.Delete.Dialog.Title": "Usuń zmienną globalną",

--- a/runbotics/runbotics-orchestrator-ui/src/src-app/types/model/global-variable.model.ts
+++ b/runbotics/runbotics-orchestrator-ui/src/src-app/types/model/global-variable.model.ts
@@ -1,7 +1,7 @@
 import { IUser } from './user.model';
 import { VariableType } from '../../views/variable/Variable.types';
 
-export type Creator = Pick<IUser, 'id' | 'login'>;
+export type UserDTO = Pick<IUser, 'id' | 'login'>;
 
 export interface IGlobalVariable {
     id?: number;
@@ -11,5 +11,5 @@ export interface IGlobalVariable {
     value: string | null;
     lastModified?: string | null;
     user?: IUser | null;
-    creator?: Creator | null;
+    creator?: UserDTO | null;
 }

--- a/runbotics/runbotics-orchestrator-ui/src/src-app/types/model/global-variable.model.ts
+++ b/runbotics/runbotics-orchestrator-ui/src/src-app/types/model/global-variable.model.ts
@@ -1,6 +1,8 @@
 import { IUser } from './user.model';
 import { VariableType } from '../../views/variable/Variable.types';
 
+export type Creator = Pick<IUser, 'id' | 'login'>;
+
 export interface IGlobalVariable {
     id?: number;
     name: string;
@@ -9,4 +11,5 @@ export interface IGlobalVariable {
     value: string | null;
     lastModified?: string | null;
     user?: IUser | null;
+    creator?: Creator | null;
 }

--- a/runbotics/runbotics-orchestrator-ui/src/src-app/views/variable/VariableListView/Table/useGlobalVariablesColumns.tsx
+++ b/runbotics/runbotics-orchestrator-ui/src/src-app/views/variable/VariableListView/Table/useGlobalVariablesColumns.tsx
@@ -14,7 +14,7 @@ import { Role } from 'runbotics-common';
 import useAuth from '#src-app/hooks/useAuth';
 import useRole from '#src-app/hooks/useRole';
 import useTranslations from '#src-app/hooks/useTranslations';
-import { IGlobalVariable, Creator } from '#src-app/types/model/global-variable.model';
+import { IGlobalVariable, UserDTO } from '#src-app/types/model/global-variable.model';
 import { IUser } from '#src-app/types/model/user.model';
 
 interface ColumnsActions {
@@ -62,7 +62,7 @@ const useGlobalVariablesColumns = ({
             headerName: translate('Variables.ListView.Table.Header.CreatedBy'),
             flex: 0.8,
             renderCell: (params: GridCellParams) => {
-                const creator = params.row.creator as Creator;
+                const creator = params.row.creator as UserDTO;
                 return creator?.login ?? '';
             },
         },
@@ -80,24 +80,22 @@ const useGlobalVariablesColumns = ({
             type: 'actions',
             flex: 0.1,
             getActions: (params: GridRowParams<IGlobalVariable>) => {
-                const creator = params.row.creator as IUser;
+                const creator = params.row.creator as UserDTO;
                 const isOwner = currentUser.id === creator.id;
-                const disabled = !(isAdmin || isOwner);
 
                 const handleEditClick = () => {
-                    if (!disabled && onEdit) onEdit(params.row);
+                    if (onEdit) onEdit(params.row);
                 };
                 const handleDeleteClick = () => {
-                    if (!disabled && onDelete) onDelete(params.row);
+                    if (onDelete) onDelete(params.row);
                 };
-                return [
+                const gridActions = [
                     <GridActionsCellItem
                         icon={<EditIcon />}
                         label={translate('Variables.ListView.Table.Actions.Edit')}
                         onClick={handleEditClick}
                         showInMenu={hasEditVariableAccess}
                         key="edit"
-                        disabled={disabled}
                     />,
                     <GridActionsCellItem
                         label={translate('Variables.ListView.Table.Actions.Delete')}
@@ -105,9 +103,9 @@ const useGlobalVariablesColumns = ({
                         onClick={handleDeleteClick}
                         showInMenu={hasDeleteVariableAccess}
                         key="delete"
-                        disabled={disabled}
                     />,
                 ];
+                return (isAdmin || isOwner) ? gridActions : [];
             },
         },
     ];

--- a/runbotics/runbotics-orchestrator-ui/src/src-app/views/variable/VariableListView/Table/useGlobalVariablesColumns.tsx
+++ b/runbotics/runbotics-orchestrator-ui/src/src-app/views/variable/VariableListView/Table/useGlobalVariablesColumns.tsx
@@ -9,8 +9,12 @@ import {
 } from '@mui/x-data-grid';
 import moment from 'moment';
 
+import { Role } from 'runbotics-common';
+
+import useAuth from '#src-app/hooks/useAuth';
+import useRole from '#src-app/hooks/useRole';
 import useTranslations from '#src-app/hooks/useTranslations';
-import { IGlobalVariable } from '#src-app/types/model/global-variable.model';
+import { IGlobalVariable, Creator } from '#src-app/types/model/global-variable.model';
 import { IUser } from '#src-app/types/model/user.model';
 
 interface ColumnsActions {
@@ -27,12 +31,14 @@ const useGlobalVariablesColumns = ({
     hasDeleteVariableAccess,
 }: ColumnsActions): GridEnrichedColDef[] => {
     const { translate } = useTranslations();
+    const { user: currentUser } = useAuth();
+    const isAdmin = useRole([Role.ROLE_ADMIN]);
 
     return [
         {
             field: 'name',
             headerName: translate('Variables.ListView.Table.Header.Name'),
-            flex: 0.8,
+            flex: 0.6,
         },
         {
             field: 'description',
@@ -42,7 +48,7 @@ const useGlobalVariablesColumns = ({
         {
             field: 'type',
             headerName: translate('Variables.ListView.Table.Header.Type'),
-            flex: 0.5,
+            flex: 0.4,
         },
         {
             field: 'lastModified',
@@ -52,9 +58,18 @@ const useGlobalVariablesColumns = ({
                 moment(params.value as string).format('YYYY-MM-DD HH:mm'),
         },
         {
+            field: 'createdBy',
+            headerName: translate('Variables.ListView.Table.Header.CreatedBy'),
+            flex: 0.8,
+            renderCell: (params: GridCellParams) => {
+                const creator = params.row.creator as Creator;
+                return creator?.login ?? '';
+            },
+        },
+        {
             field: 'modifiedBy',
             headerName: translate('Variables.ListView.Table.Header.ModifiedBy'),
-            flex: 0.6,
+            flex: 0.8,
             renderCell: (params: GridCellParams) => {
                 const user = params.row.user as IUser;
                 return user?.login ?? '';
@@ -63,12 +78,17 @@ const useGlobalVariablesColumns = ({
         {
             field: 'actions',
             type: 'actions',
+            flex: 0.1,
             getActions: (params: GridRowParams<IGlobalVariable>) => {
+                const creator = params.row.creator as IUser;
+                const isOwner = currentUser.id === creator.id;
+                const disabled = !(isAdmin || isOwner);
+
                 const handleEditClick = () => {
-                    if (onEdit) onEdit(params.row);
+                    if (!disabled && onEdit) onEdit(params.row);
                 };
                 const handleDeleteClick = () => {
-                    if (onDelete) onDelete(params.row);
+                    if (!disabled && onDelete) onDelete(params.row);
                 };
                 return [
                     <GridActionsCellItem
@@ -77,6 +97,7 @@ const useGlobalVariablesColumns = ({
                         onClick={handleEditClick}
                         showInMenu={hasEditVariableAccess}
                         key="edit"
+                        disabled={disabled}
                     />,
                     <GridActionsCellItem
                         label={translate('Variables.ListView.Table.Actions.Delete')}
@@ -84,6 +105,7 @@ const useGlobalVariablesColumns = ({
                         onClick={handleDeleteClick}
                         showInMenu={hasDeleteVariableAccess}
                         key="delete"
+                        disabled={disabled}
                     />,
                 ];
             },

--- a/runbotics/runbotics-scheduler/package.json
+++ b/runbotics/runbotics-scheduler/package.json
@@ -1,6 +1,6 @@
 {
     "name": "runbotics-scheduler",
-    "version": "2.8.0-SNAPSHOT.61",
+    "version": "2.8.0-SNAPSHOT.62",
     "author": {
         "name": "runbotics",
         "email": "contact@runbotics.com"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above (if possible start with issue number with # prefix) -->
<!--- Example: #123 - Some description -->

## Description

<img width="960" alt="image" src="https://github.com/runbotics/runbotics/assets/82586165/fdd2750c-995e-451d-b6d5-a8be4b3bf312">

<img width="960" alt="image" src="https://github.com/runbotics/runbotics/assets/82586165/3a991b69-b225-4622-893e-34c3c6320735">

<img width="959" alt="image" src="https://github.com/runbotics/runbotics/assets/82586165/51286f19-fef6-4a02-bcef-7c1c72549f11">

DONE:
1. block the option to edit a global variable for anyone who is not an admin or owner of the variable
2. block the option to delete a global variable for anyone who is not an admin or owner of the variable
3. add a variable creator column in the table

<!--- Describe your changes in detail, provide screenshots if necessary -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

---

I agree to the terms of the RunBotics Contributor License Agreement.