### PR TITLE
[RPA-1328] Adds feature to search for variables in activities on ctrl+F

### DIFF
--- a/runbotics-orchestrator/build.gradle
+++ b/runbotics-orchestrator/build.gradle
@@ -26,7 +26,7 @@ plugins {
 
 group = "com.runbotics"
 
-version = "2.10.0-SNAPSHOT.56"
+version = "2.10.0-SNAPSHOT.57"
 description = ""
 
 sourceCompatibility=11

--- a/runbotics/common/config/runbotics.json
+++ b/runbotics/common/config/runbotics.json
@@ -1,3 +1,3 @@
 {
-    "version": "2.10.0-SNAPSHOT.56"
+    "version": "2.10.0-SNAPSHOT.57"
 }

--- a/runbotics/runbotics-desktop/package.json
+++ b/runbotics/runbotics-desktop/package.json
@@ -1,6 +1,6 @@
 {
     "name": "runbotics-desktop",
-    "version": "2.10.0-SNAPSHOT.56",
+    "version": "2.10.0-SNAPSHOT.57",
     "author": {
         "name": "runbotics",
         "email": "contact@runbotics.com"

--- a/runbotics/runbotics-orchestrator-ui/package.json
+++ b/runbotics/runbotics-orchestrator-ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "runbotics-orchestrator-ui",
-    "version": "2.10.0-SNAPSHOT.56",
+    "version": "2.10.0-SNAPSHOT.57",
     "author": {
         "name": "runbotics",
         "email": "contact@runbotics.com"

--- a/runbotics/runbotics-orchestrator-ui/src/src-app/utils/findVariablesInActivities.ts
+++ b/runbotics/runbotics-orchestrator-ui/src/src-app/utils/findVariablesInActivities.ts
@@ -66,7 +66,7 @@ const findOutputVariablesInAction = (outputValues: CamundaOutputParameter[], sea
     return [...outputVariable, ...hashVariables].length > 0;
 };
 
-const findHashDollarVariable = (extensionElementValues: CamundaInputParameter[] | CamundaOutputParameter[], searchPhrase: string) =>
+const findHashDollarVariable = (extensionElementValues: CamundaParameter[], searchPhrase: string) =>
     extensionElementValues
         .filter(value => value.name === 'variables' || value.name === 'functionParams')
         .map((camundaParam: CamundaParameter) => Object.values(getParameterValue(camundaParam)))

--- a/runbotics/runbotics-orchestrator-ui/src/src-app/utils/findVariablesInActivities.ts
+++ b/runbotics/runbotics-orchestrator-ui/src/src-app/utils/findVariablesInActivities.ts
@@ -1,0 +1,73 @@
+import {
+    BPMNElement,
+    CamundaInputParameter,
+    CamundaOutputParameter,
+    CamundaParameter,
+    IBpmnGateway,
+    IBpmnSubProcessBusinessObject,
+    ISequenceFlowBusinessObject,
+    getParameterValue
+} from '#src-app/views/process/ProcessBuildView/Modeler/helpers/elementParameters';
+
+export const findVariablesInGateway = (businessObject: IBpmnGateway, searchPhrase: string): boolean => {
+    const gatewayOutgoingFlows: ISequenceFlowBusinessObject[] = businessObject.outgoing as unknown as ISequenceFlowBusinessObject[];
+
+    const gatewayExpressions = gatewayOutgoingFlows
+        .map(flow => flow.conditionExpression.body.toLowerCase())
+        .filter(expression => expression.includes(searchPhrase));
+
+    return gatewayExpressions.length > 0;
+};
+
+export const findVariablesInLoop = (element: BPMNElement, searchPhrase: string): boolean => {
+    const loopVariable = (element.businessObject as IBpmnSubProcessBusinessObject).loopCharacteristics.loopCardinality.body;
+    return loopVariable.toLowerCase().includes(searchPhrase);
+};
+export const findVariablesInAction = (element: BPMNElement, searchPhrase: string): boolean => {
+    let variableFound = false;
+    const extensionElements = element.businessObject.extensionElements;
+
+    if (!extensionElements) {
+        return false;
+    }
+
+    const inputValues = extensionElements.values[0].inputParameters;
+    const outputValues = extensionElements.values[0].outputParameters;
+
+    if (inputValues && inputValues.length > 0) {
+        const inputVariable = inputValues.filter(
+            value =>
+                (value.name === 'variable' && value.value.toLowerCase().includes(searchPhrase)) ||
+                (value.name === 'value' &&
+                    (value.value.startsWith('#{') || value.value.startsWith('${')) &&
+                    value.value.toLowerCase().includes(searchPhrase))
+        );
+
+        const hashVariables = findHashDollarVariable(inputValues, searchPhrase);
+            
+        variableFound = [...inputVariable, ...hashVariables].length > 0;
+    }
+
+    if (variableFound) {
+        return variableFound;
+    }
+
+    if (outputValues && outputValues.length > 0) {
+        const outputVariable = outputValues.filter(
+            value => value.name === 'variableName' && value.value.toLowerCase().includes(searchPhrase)
+        );
+
+        const hashVariables = findHashDollarVariable(outputValues, searchPhrase);
+
+        variableFound = [...outputVariable, ...hashVariables].length > 0;
+    }
+
+    return false;
+};
+
+const findHashDollarVariable = (extensionElementValues: CamundaInputParameter[] | CamundaOutputParameter[], searchPhrase: string) =>
+    extensionElementValues
+        .filter(value => value.name === 'variables' || value.name === 'functionParams')
+        .map((camundaParam: CamundaParameter) => Object.values(getParameterValue(camundaParam)))
+        .flatMap(arr => arr)
+        .filter((foundValue: string) => foundValue.toLowerCase().includes(searchPhrase));

--- a/runbotics/runbotics-orchestrator-ui/src/src-app/utils/findVariablesInActivities.ts
+++ b/runbotics/runbotics-orchestrator-ui/src/src-app/utils/findVariablesInActivities.ts
@@ -24,54 +24,46 @@ export const findVariablesInLoop = (element: BPMNElement, searchPhrase: string):
     return loopVariable.toLowerCase().includes(searchPhrase);
 };
 export const findVariablesInAction = (element: BPMNElement, searchPhrase: string): boolean => {
-    let variableFound = false;
     const extensionElements = element.businessObject.extensionElements;
 
-    if (!extensionElements) {
-        return false;
-    }
+    if (!extensionElements) return false;
 
     const inputValues = extensionElements.values[0].inputParameters;
     const outputValues = extensionElements.values[0].outputParameters;
 
-    // console.log(outputValues);
-
-    if (inputValues && inputValues.length > 0) {
-        const inputVariable = inputValues.filter(
-            value =>
-                (value.name === 'variable' && value.value.toLowerCase().includes(searchPhrase)) ||
-                (value.name === 'value' &&
-                    (value.value.startsWith('#{') || value.value.startsWith('${')) &&
-                    value.value.toLowerCase().includes(searchPhrase))
-        );
-
-        const hashVariables = findHashDollarVariable(inputValues, searchPhrase);
-            
-        variableFound = [...inputVariable, ...hashVariables].length > 0;
+    if (
+        (inputValues && inputValues.length > 0 && findInputVariablesInAction(inputValues, searchPhrase)) ||
+        (outputValues && outputValues.length > 0 && findOutputVariablesInAction(outputValues, searchPhrase))
+    ) {
+        return true;
     }
 
-    if (variableFound) {
-        return variableFound;
-    }
+    return false;
+};
 
-    if (outputValues && outputValues.length > 0) {
-        if (element.id === 'Activity_115xecy') {
-            console.log(element);
-            outputValues.forEach(value => {
-                console.log(value.name, value.value.toLowerCase().includes(searchPhrase));
-            });
-        }
-        const outputVariable = outputValues.filter(
-            value => value.name === 'variableName' && value.value.toLowerCase().includes(searchPhrase)
-        );
+const findInputVariablesInAction = (inputValues: CamundaInputParameter[], searchPhrase: string) => {
+    const inputVariable = inputValues.filter(
+        value =>
+            (value.name === 'variable' && value.value.toLowerCase().includes(searchPhrase)) ||
+            (value.name === 'value' &&
+                value.value &&
+                (value.value.startsWith('#{') || value.value.startsWith('${')) &&
+                value.value.toLowerCase().includes(searchPhrase))
+    );
 
-        const hashVariables = findHashDollarVariable(outputValues, searchPhrase);
-        console.log('outputVariable', outputVariable);
+    const hashVariables = findHashDollarVariable(inputValues, searchPhrase);
 
-        variableFound = [...outputVariable, ...hashVariables].length > 0;
-    }
+    return [...inputVariable, ...hashVariables].length > 0;
+};
 
-    return variableFound;
+const findOutputVariablesInAction = (outputValues: CamundaOutputParameter[], searchPhrase: string) => {
+    const outputVariable = outputValues.filter(
+        value => value.name === 'variableName' && value.value && value.value.toLowerCase().includes(searchPhrase)
+    );
+
+    const hashVariables = findHashDollarVariable(outputValues, searchPhrase);
+
+    return [...outputVariable, ...hashVariables].length > 0;
 };
 
 const findHashDollarVariable = (extensionElementValues: CamundaInputParameter[] | CamundaOutputParameter[], searchPhrase: string) =>

--- a/runbotics/runbotics-orchestrator-ui/src/src-app/utils/findVariablesInActivities.ts
+++ b/runbotics/runbotics-orchestrator-ui/src/src-app/utils/findVariablesInActivities.ts
@@ -34,6 +34,8 @@ export const findVariablesInAction = (element: BPMNElement, searchPhrase: string
     const inputValues = extensionElements.values[0].inputParameters;
     const outputValues = extensionElements.values[0].outputParameters;
 
+    // console.log(outputValues);
+
     if (inputValues && inputValues.length > 0) {
         const inputVariable = inputValues.filter(
             value =>
@@ -53,16 +55,23 @@ export const findVariablesInAction = (element: BPMNElement, searchPhrase: string
     }
 
     if (outputValues && outputValues.length > 0) {
+        if (element.id === 'Activity_115xecy') {
+            console.log(element);
+            outputValues.forEach(value => {
+                console.log(value.name, value.value.toLowerCase().includes(searchPhrase));
+            });
+        }
         const outputVariable = outputValues.filter(
             value => value.name === 'variableName' && value.value.toLowerCase().includes(searchPhrase)
         );
 
         const hashVariables = findHashDollarVariable(outputValues, searchPhrase);
+        console.log('outputVariable', outputVariable);
 
         variableFound = [...outputVariable, ...hashVariables].length > 0;
     }
 
-    return false;
+    return variableFound;
 };
 
 const findHashDollarVariable = (extensionElementValues: CamundaInputParameter[] | CamundaOutputParameter[], searchPhrase: string) =>

--- a/runbotics/runbotics-orchestrator-ui/src/src-app/utils/getActivityType.ts
+++ b/runbotics/runbotics-orchestrator-ui/src/src-app/utils/getActivityType.ts
@@ -1,0 +1,16 @@
+import { BPMNElement } from '#src-app/views/process/ProcessBuildView/Modeler/helpers/elementParameters';
+
+export enum Activity {
+    GATEWAY = 'gateway',
+    ACTION = 'action',
+    LOOP = 'loop'
+}
+
+export const getActivityType = (element: BPMNElement): string | null => {
+    if (element.id.startsWith('Gateway')) return Activity.GATEWAY;
+    if (element.id.startsWith('Activity')) return Activity.ACTION;
+    if (element.businessObject.actionId === 'loop.loop') return Activity.LOOP;
+
+    return null;
+};
+

--- a/runbotics/runbotics-orchestrator-ui/src/src-app/utils/getActivityType.ts
+++ b/runbotics/runbotics-orchestrator-ui/src/src-app/utils/getActivityType.ts
@@ -7,9 +7,9 @@ export enum Activity {
 }
 
 export const getActivityType = (element: BPMNElement): string | null => {
+    if (element.businessObject.actionId === 'loop.loop') return Activity.LOOP;
     if (element.id.startsWith('Gateway')) return Activity.GATEWAY;
     if (element.id.startsWith('Activity')) return Activity.ACTION;
-    if (element.businessObject.actionId === 'loop.loop') return Activity.LOOP;
 
     return null;
 };

--- a/runbotics/runbotics-orchestrator-ui/src/src-app/views/process/ProcessBuildView/Modeler/extensions/search/BpmnSearch.ts
+++ b/runbotics/runbotics-orchestrator-ui/src/src-app/views/process/ProcessBuildView/Modeler/extensions/search/BpmnSearch.ts
@@ -1,6 +1,7 @@
+
 import getElementLabel from '#src-app/utils/getElementLabel';
 
-import { BPMNElement } from '../../helpers/elementParameters';
+import { BPMNElement, CamundaParameter, IBpmnSubProcessBusinessObject, ISequenceFlowBusinessObject, getParameterValue } from '../../helpers/elementParameters';
 
 interface Token {
     normal?: string;
@@ -31,25 +32,30 @@ export default class BpmnSearchProvider implements SearchProvider {
 
     public find(pattern: string): Result[] {
         const rootElement = this._canvas.getRootElement();
-        return this._elementRegistry
+
+        const foundVariablesInActivities = this._elementRegistry
+            .filter((element: BPMNElement) => element !== rootElement && hasVariables(element, pattern))
+            .map((element: BPMNElement) => ({
+                primaryTokens: [{ normal: `variable in: ${element.id.startsWith('Gateway') ? element.id : getElementLabel(element)}` }],
+                secondaryTokens: [],
+                element: element
+            }))
+            .sort((item: Result) => item + item.element.id);
+
+        const actions = this._elementRegistry
             .filter(
                 (element: BPMNElement) =>
-                    element !== rootElement && element.id.startsWith('Activity')
+                    (element !== rootElement && hasVariables(element, pattern)) || (rootElement && element.id.startsWith('Activity'))
             )
             .map((element: BPMNElement) => ({
                 primaryTokens: matchAndSplit(getElementLabel(element), pattern),
                 secondaryTokens: [],
                 element: element
             }))
-            .filter(
-                (item: Result) =>
-                    hasMatched(item.primaryTokens) ||
-                    hasMatched(item.secondaryTokens)
-            )
-            .sort(
-                (item: Result) =>
-                    getElementLabel(item.element) + item.element.id
-            );
+            .filter((item: Result) => hasMatched(item.primaryTokens) || hasMatched(item.secondaryTokens))
+            .sort((item: Result) => getElementLabel(item.element) + item.element.id);
+
+        return [...foundVariablesInActivities, ...actions];
     }
 }
 
@@ -57,6 +63,78 @@ const hasMatched = (tokens: Token[]): boolean => {
     const matched = tokens.filter((token: Token) => Boolean(token.matched));
 
     return matched.length > 0;
+};
+
+const hasVariables = (element: BPMNElement, pattern: string) => {
+    const lowerCasePattern = pattern.toLowerCase();
+    const businessObject = element.businessObject;
+    let variableFound = false;
+
+    if (element.id.startsWith('Gateway')) {
+        const gatewayOutgoingFlows: ISequenceFlowBusinessObject[] = (businessObject as unknown as BPMNElement)
+            .outgoing as unknown as ISequenceFlowBusinessObject[];
+
+        const gatewayExpressions = gatewayOutgoingFlows
+            .map(flow => flow.conditionExpression.body.toLowerCase())
+            .filter(expression => expression.includes(lowerCasePattern));
+
+        variableFound = gatewayExpressions.length > 0;
+    }
+
+    if (variableFound) {
+        return variableFound;
+    }
+    
+    if (businessObject.actionId === 'loop.loop') {
+        const loopVariable = (element.businessObject as IBpmnSubProcessBusinessObject).loopCharacteristics.loopCardinality.body;
+        variableFound = loopVariable.toLowerCase().includes(lowerCasePattern);
+    }
+
+    if (variableFound) {
+        return variableFound;
+    }
+
+    const extensionElements = businessObject.extensionElements;
+
+    if (!extensionElements) {
+        return variableFound;
+    }
+
+    const inputValues = extensionElements.values[0].inputParameters;
+    const outputValues = extensionElements.values[0].outputParameters;
+
+    if (inputValues && inputValues.length > 0) {
+        const inputVariable = inputValues.filter(
+            value =>
+                (value.name === 'variable' && value.value.toLowerCase().includes(lowerCasePattern)) ||
+                (value.name === 'value' && (value.value.startsWith('#{') || value.value.startsWith('${')) && value.value.toLowerCase().includes(lowerCasePattern))
+        );
+
+        const hashVariables = inputValues
+            .filter(value => value.name === 'variables' || value.name === 'functionParams')
+            .map((camundaParam: CamundaParameter) => Object.values(getParameterValue(camundaParam)))
+            .flatMap(arr => arr)
+            .filter((foundValue: string) => foundValue.toLowerCase().includes(lowerCasePattern));
+
+        variableFound = [...inputVariable, ...hashVariables].length > 0;
+    }
+
+    if (variableFound) {
+        return variableFound;
+    }
+
+    if (outputValues && outputValues.length > 0) {
+        const outputVariable = outputValues.filter(
+            value => value.name === 'variableName' && value.value.toLowerCase().includes(lowerCasePattern)
+        );
+        variableFound = outputVariable.length > 0;
+    }
+
+    if (variableFound) {
+        return variableFound;
+    }
+
+    return false;
 };
 
 const matchAndSplit = (text: string, pattern: string): Token[] => {

--- a/runbotics/runbotics-scheduler/package.json
+++ b/runbotics/runbotics-scheduler/package.json
@@ -1,6 +1,6 @@
 {
     "name": "runbotics-scheduler",
-    "version": "2.10.0-SNAPSHOT.56",
+    "version": "2.10.0-SNAPSHOT.57",
     "author": {
         "name": "runbotics",
         "email": "contact@runbotics.com"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above (if possible start with issue number with # prefix) -->
<!--- Example: #123 - Some description -->

## Description

On ctrl+f you can now search for a variable. In case variable is found in an activity (it can be action, gateway or loop) it is displayed as below:
![image](https://github.com/runbotics/runbotics/assets/61866178/395837de-98ce-41e9-a368-af55f36c3d1d)

Functionality with searching for an action is maintained (phrase found in action is bolded), sorting is done like this: fist actions where variable is found are listed (in alpha order - in case 2 actions has the same name it is sorted by ID), then actions are listed.
![image](https://github.com/runbotics/runbotics/assets/61866178/bba079ee-e1f7-46c1-a77c-9a02d3e0481c)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

---

I agree to the terms of the RunBotics Contributor License Agreement.