### PR TITLE
[RPA-1734] Fixes mandatory dataWidget 

### DIFF
--- a/runbotics-orchestrator/build.gradle
+++ b/runbotics-orchestrator/build.gradle
@@ -26,7 +26,7 @@ plugins {
 
 group = "com.runbotics"
 
-version = "2.11.0-SNAPSHOT.92"
+version = "2.11.0-SNAPSHOT.93"
 description = ""
 
 sourceCompatibility=11

--- a/runbotics/common/config/runbotics.json
+++ b/runbotics/common/config/runbotics.json
@@ -1,3 +1,3 @@
 {
-    "version": "2.11.0-SNAPSHOT.92"
+    "version": "2.11.0-SNAPSHOT.93"
 }

--- a/runbotics/runbotics-desktop/package.json
+++ b/runbotics/runbotics-desktop/package.json
@@ -1,6 +1,6 @@
 {
     "name": "runbotics-desktop",
-    "version": "2.11.0-SNAPSHOT.92",
+    "version": "2.11.0-SNAPSHOT.93",
     "author": {
         "name": "runbotics",
         "email": "contact@runbotics.com"

--- a/runbotics/runbotics-orchestrator-ui/package.json
+++ b/runbotics/runbotics-orchestrator-ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "runbotics-orchestrator-ui",
-    "version": "2.11.0-SNAPSHOT.92",
+    "version": "2.11.0-SNAPSHOT.93",
     "author": {
         "name": "runbotics",
         "email": "contact@runbotics.com"

--- a/runbotics/runbotics-orchestrator-ui/src/src-app/views/process/ProcessBuildView/Modeler/ActionFormPanel/widgets/DatePickerWidget/DatePickerWidget.tsx
+++ b/runbotics/runbotics-orchestrator-ui/src/src-app/views/process/ProcessBuildView/Modeler/ActionFormPanel/widgets/DatePickerWidget/DatePickerWidget.tsx
@@ -62,7 +62,7 @@ const DatePickerWidget: FC<WidgetProps> = ({ uiSchema, onChange, label, required
             {...params}
             label={label}
             required={required}
-            color={selectedDate && required === null ? 'error' : 'primary'}
+            color={selectedDate === null ? 'error' : 'primary'}
             sx={{
                 button: { marginRight: (theme) => theme.spacing(0.5) },
                 caretColor: 'transparent',

--- a/runbotics/runbotics-orchestrator-ui/src/src-app/views/process/ProcessBuildView/Modeler/ActionFormPanel/widgets/DatePickerWidget/DatePickerWidget.tsx
+++ b/runbotics/runbotics-orchestrator-ui/src/src-app/views/process/ProcessBuildView/Modeler/ActionFormPanel/widgets/DatePickerWidget/DatePickerWidget.tsx
@@ -45,24 +45,24 @@ const checkFormat = (format: any) => {
     return { inputFormat: format, views: inputTypes['date-time'].views };
 };
 
-const DatePickerWidget: FC<WidgetProps> = (props) => {
+const DatePickerWidget: FC<WidgetProps> = ({ uiSchema, onChange, label, required }) => {
     const [selectedDate, setSelectedDate] = useState<Date | null>(null);
-    const format = props.uiSchema['ui:options']?.format;
+    const format = uiSchema['ui:options']?.format;
     const { inputFormat, views } = checkFormat(format);
 
     const handleDateChange = (date: Date | null) => {
         setSelectedDate(date);
         if (date !== null) {
-            props.onChange(moment(date).format(inputFormat));
+            onChange(moment(date).format(inputFormat));
         }
     };
 
     const renderInput = (params: any) => (
         <TextField
             {...params}
-            label={props.label}
-            required={props.required}
-            color={selectedDate === null ? 'error' : 'primary'}
+            label={label}
+            required={required}
+            color={selectedDate && required === null ? 'error' : 'primary'}
             sx={{
                 button: { marginRight: (theme) => theme.spacing(0.5) },
                 caretColor: 'transparent',
@@ -86,7 +86,7 @@ const DatePickerWidget: FC<WidgetProps> = (props) => {
                         event.preventDefault();
                     },
                 }}
-                error={selectedDate === null}
+                error={required && selectedDate === null}
             />
         </LocalizationProvider>
     );

--- a/runbotics/runbotics-scheduler/package.json
+++ b/runbotics/runbotics-scheduler/package.json
@@ -1,6 +1,6 @@
 {
     "name": "runbotics-scheduler",
-    "version": "2.11.0-SNAPSHOT.92",
+    "version": "2.11.0-SNAPSHOT.93",
     "author": {
         "name": "runbotics",
         "email": "contact@runbotics.com"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above (if possible start with issue number with # prefix) -->
<!--- Example: #123 - Some description -->

## Description
Fixes issue when dataWidget was always showing as mandatory input for the users.

Before date widget was displayed as mandatory even though it was not included in required array:
![image](https://github.com/user-attachments/assets/e1a3d570-4798-4157-96c1-f81f47f1ed66)

Now:
- if not required:
![image](https://github.com/user-attachments/assets/55fcffd3-eacb-4c9d-b467-f9f54b8d4a38)

- if required:
![image](https://github.com/user-attachments/assets/eb5e22ef-431a-41b7-a454-33b1f00fad29)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

---

I agree to the terms of the RunBotics Contributor License Agreement.