### PR TITLE
[RPA-1888] Credential edit access fix + minor credential fixes

### DIFF
--- a/runbotics-orchestrator/build.gradle
+++ b/runbotics-orchestrator/build.gradle
@@ -26,7 +26,7 @@ plugins {
 
 group = "com.runbotics"
 
-version = "2.11.0-SNAPSHOT.119"
+version = "2.11.0-SNAPSHOT.120"
 description = ""
 
 sourceCompatibility=11

--- a/runbotics-orchestrator/build.gradle
+++ b/runbotics-orchestrator/build.gradle
@@ -26,7 +26,7 @@ plugins {
 
 group = "com.runbotics"
 
-version = "2.11.0-SNAPSHOT.121"
+version = "2.11.0-SNAPSHOT.122"
 description = ""
 
 sourceCompatibility=11

--- a/runbotics/common/config/runbotics.json
+++ b/runbotics/common/config/runbotics.json
@@ -1,3 +1,3 @@
 {
-    "version": "2.11.0-SNAPSHOT.121"
+    "version": "2.11.0-SNAPSHOT.122"
 }

--- a/runbotics/common/config/runbotics.json
+++ b/runbotics/common/config/runbotics.json
@@ -1,3 +1,3 @@
 {
-    "version": "2.11.0-SNAPSHOT.119"
+    "version": "2.11.0-SNAPSHOT.120"
 }

--- a/runbotics/runbotics-desktop/package.json
+++ b/runbotics/runbotics-desktop/package.json
@@ -1,6 +1,6 @@
 {
     "name": "runbotics-desktop",
-    "version": "2.11.0-SNAPSHOT.121",
+    "version": "2.11.0-SNAPSHOT.122",
     "author": {
         "name": "runbotics",
         "email": "contact@runbotics.com"

--- a/runbotics/runbotics-desktop/package.json
+++ b/runbotics/runbotics-desktop/package.json
@@ -1,6 +1,6 @@
 {
     "name": "runbotics-desktop",
-    "version": "2.11.0-SNAPSHOT.119",
+    "version": "2.11.0-SNAPSHOT.120",
     "author": {
         "name": "runbotics",
         "email": "contact@runbotics.com"

--- a/runbotics/runbotics-orchestrator-ui/package.json
+++ b/runbotics/runbotics-orchestrator-ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "runbotics-orchestrator-ui",
-    "version": "2.11.0-SNAPSHOT.119",
+    "version": "2.11.0-SNAPSHOT.120",
     "author": {
         "name": "runbotics",
         "email": "contact@runbotics.com"

--- a/runbotics/runbotics-orchestrator-ui/package.json
+++ b/runbotics/runbotics-orchestrator-ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "runbotics-orchestrator-ui",
-    "version": "2.11.0-SNAPSHOT.121",
+    "version": "2.11.0-SNAPSHOT.122",
     "author": {
         "name": "runbotics",
         "email": "contact@runbotics.com"

--- a/runbotics/runbotics-orchestrator-ui/src/src-app/components/Tile/CredentialTile/CredentialTile.tsx
+++ b/runbotics/runbotics-orchestrator-ui/src/src-app/components/Tile/CredentialTile/CredentialTile.tsx
@@ -55,9 +55,9 @@ const CredentialTile: FC<CredentialTileProps> = ({
     };
 
     return (
-        <CredentialCardContainer onClick={handleClick}>
+        <CredentialCardContainer >
             <Tile leftbordercolor={`4px solid ${hexColor}`}>
-                <CredentialCard>
+                <CredentialCard onClick={handleClick}>
                     <Typography variant="h4" sx={{ paddingBottom: '16px' }}>
                         {credential.name}
                     </Typography>

--- a/runbotics/runbotics-orchestrator-ui/src/src-app/components/Tile/CredentialTile/CredentialTile.tsx
+++ b/runbotics/runbotics-orchestrator-ui/src/src-app/components/Tile/CredentialTile/CredentialTile.tsx
@@ -55,9 +55,9 @@ const CredentialTile: FC<CredentialTileProps> = ({
     };
 
     return (
-        <CredentialCardContainer >
+        <CredentialCardContainer onClick={handleClick}>
             <Tile leftbordercolor={`4px solid ${hexColor}`}>
-                <CredentialCard onClick={handleClick}>
+                <CredentialCard>
                     <Typography variant="h4" sx={{ paddingBottom: '16px' }}>
                         {credential.name}
                     </Typography>

--- a/runbotics/runbotics-orchestrator-ui/src/src-app/views/credentials/Credential/EditCredential/CredentialAttribute/Attribute.styles.ts
+++ b/runbotics/runbotics-orchestrator-ui/src/src-app/views/credentials/Credential/EditCredential/CredentialAttribute/Attribute.styles.ts
@@ -5,7 +5,6 @@ import styled from 'styled-components';
 export const StyledGridContainer = styled(Grid)(
     ({ theme }) => `
     padding: ${theme.spacing(1)};
-    align-items: flex-end;
     `
 );
 

--- a/runbotics/runbotics-orchestrator-ui/src/src-app/views/credentials/Credential/EditCredential/CredentialAttribute/TemplateAttribute.tsx
+++ b/runbotics/runbotics-orchestrator-ui/src/src-app/views/credentials/Credential/EditCredential/CredentialAttribute/TemplateAttribute.tsx
@@ -36,6 +36,7 @@ const TemplateAttribute: FC<TemplateAttributeProps> = ({ credentialId, attribute
         value: ''
     });
     const { enqueueSnackbar } = useSnackbar();
+    const isEditable = canEdit && isEditMode;
 
     const handleCancel = () => {
         setCurrentAttribute({
@@ -79,47 +80,51 @@ const TemplateAttribute: FC<TemplateAttributeProps> = ({ credentialId, attribute
 
     return (
         <StyledAttributeCard iseditmode={isEditMode.toString()}>
-            <StyledGridContainer container rowSpacing={2}>
-                <Grid item xs={12}>
-                    <Typography variant="h6">{translate('Credential.Attribute.Name.Label')}</Typography>
-                    <AttributeInfoNotEdiable>{attribute.name}</AttributeInfoNotEdiable>
-                </Grid>
-                <Grid item xs={12} marginBottom="16px">
-                    <Typography variant="h6">{translate('Credential.Attribute.Description.Label')}</Typography>
-                    <AttributeInfoNotEdiable>{attribute.description}</AttributeInfoNotEdiable>
-                </Grid>
-                <CredentialAttributeDetails
-                    handleFieldChange={handleFieldChange}
-                    currentAttribute={currentAttribute}
-                    isEditMode={isEditMode}
-                    canEdit={canEdit}
-                    setIsEditMode={setIsEditMode}
-                />
-                <Collapse in={isEditMode} orientation="vertical" sx={{ width: '100%' }}>
-                    <Grid container justifyContent="space-between">
-                        <Grid item>
-                            <Button size="small" onClick={handleCancel} sx={{ padding: 0, color: grey[600] }}>
-                                <AttributeIcon>
-                                    <ClearIcon />
-                                </AttributeIcon>
-                                <Typography variant="h5">{translate('Common.Cancel').toUpperCase()}</Typography>
-                            </Button>
-                        </Grid>
-                        <Grid item>
-                            <Button
-                                size="small"
-                                color="secondary"
-                                onClick={() => handleConfirm(credentialId, attribute.name)}
-                                sx={{ padding: '0 8px 0 0' }}
-                            >
-                                <AttributeIcon color="inherit">
-                                    <DoneIcon />
-                                </AttributeIcon>
-                                <Typography variant="h5">{translate('Common.Confirm').toUpperCase()}</Typography>
-                            </Button>
-                        </Grid>
+            <StyledGridContainer container>
+                <Grid container xs={12} marginBottom="16px">
+                    <Grid item xs={12} marginBottom="16px">
+                        <Typography variant="h6">{translate('Credential.Attribute.Name.Label')}</Typography>
+                        <AttributeInfoNotEdiable>{attribute.name}</AttributeInfoNotEdiable>
                     </Grid>
-                </Collapse>
+                    <Grid item xs={12}>
+                        <Typography variant="h6">{translate('Credential.Attribute.Description.Label')}</Typography>
+                        <AttributeInfoNotEdiable>{attribute.description}</AttributeInfoNotEdiable>
+                    </Grid>
+                </Grid>
+                <Grid item xs={12} alignSelf="flex-end">
+                    <CredentialAttributeDetails
+                        handleFieldChange={handleFieldChange}
+                        currentAttribute={currentAttribute}
+                        isEditMode={isEditable}
+                        canEdit={canEdit}
+                        setIsEditMode={setIsEditMode}
+                    />
+                    <Collapse in={isEditable} orientation="vertical" sx={{ width: '100%' }}>
+                        <Grid container justifyContent="space-between">
+                            <Grid item>
+                                <Button size="small" onClick={handleCancel} sx={{ padding: 0, color: grey[600] }}>
+                                    <AttributeIcon>
+                                        <ClearIcon />
+                                    </AttributeIcon>
+                                    <Typography variant="h5">{translate('Common.Cancel').toUpperCase()}</Typography>
+                                </Button>
+                            </Grid>
+                            <Grid item>
+                                <Button
+                                    size="small"
+                                    color="secondary"
+                                    onClick={() => handleConfirm(credentialId, attribute.name)}
+                                    sx={{ padding: '0 8px 0 0' }}
+                                >
+                                    <AttributeIcon color="inherit">
+                                        <DoneIcon />
+                                    </AttributeIcon>
+                                    <Typography variant="h5">{translate('Common.Confirm').toUpperCase()}</Typography>
+                                </Button>
+                            </Grid>
+                        </Grid>
+                    </Collapse>
+                </Grid>
             </StyledGridContainer>
         </StyledAttributeCard>
     );

--- a/runbotics/runbotics-orchestrator-ui/src/src-app/views/credentials/Credential/EditCredential/EditCredential.tsx
+++ b/runbotics/runbotics-orchestrator-ui/src/src-app/views/credentials/Credential/EditCredential/EditCredential.tsx
@@ -3,11 +3,10 @@ import { useEffect } from 'react';
 import { Grid, Typography } from '@mui/material';
 
 import { useRouter } from 'next/router';
-import { useDispatch } from 'react-redux';
 
 import { translate } from '#src-app/hooks/useTranslations';
 
-import { useSelector } from '#src-app/store';
+import { useDispatch, useSelector } from '#src-app/store';
 import { credentialCollectionsActions, credentialCollectionsSelector } from '#src-app/store/slices/CredentialCollections';
 import { credentialsActions, credentialsSelector } from '#src-app/store/slices/Credentials';
 import { getLastParamOfUrl } from '#src-app/views/utils/routerUtils';
@@ -32,8 +31,17 @@ const EditCredential = () => {
     const isNewCredential = isCreatedNow(credential?.createdAt);
 
     useEffect(() => {
-        dispatch(credentialsActions.fetchOneCredential({ resourceId: credentialId }));
-        if (!credentialCollections) dispatch(credentialCollectionsActions.fetchAllCredentialCollections());
+        dispatch(credentialsActions.fetchOneCredential({ resourceId: credentialId }))
+            .unwrap()
+            .then(() => {
+                if (!credentialCollections) {
+                    dispatch(credentialCollectionsActions.fetchAllCredentialCollections());
+                }
+            })
+            .catch(() => {
+                router.replace('/404');
+
+            });
     }, [credentialId, credentialCollections]);
 
     return (

--- a/runbotics/runbotics-orchestrator-ui/src/src-app/views/credentials/Credential/EditCredential/EditCredential.tsx
+++ b/runbotics/runbotics-orchestrator-ui/src/src-app/views/credentials/Credential/EditCredential/EditCredential.tsx
@@ -40,7 +40,6 @@ const EditCredential = () => {
             })
             .catch(() => {
                 router.replace('/404');
-
             });
     }, [credentialId, credentialCollections]);
 

--- a/runbotics/runbotics-orchestrator-ui/src/src-app/views/credentials/Credential/EditCredential/EditCredentialForm.tsx
+++ b/runbotics/runbotics-orchestrator-ui/src/src-app/views/credentials/Credential/EditCredential/EditCredentialForm.tsx
@@ -53,10 +53,15 @@ export const EditCredentialForm: FC<EditCredentialFormProps> = ({ open: isOpen, 
                 enqueueSnackbar(translate('Credential.Form.Edit.Success', { name: credentialFormState.name }), { variant: 'success' });
                 dispatch(
                     credentialsActions.fetchAllCredentialsAccessibleInTenantByPage({
-                        pageParams: { page: 0, size: pageSize, filter: {
-                            equals: {
-                                collectionId: collectionId ? collectionId : ''}
-                        } }
+                        pageParams: {
+                            page: 0,
+                            size: pageSize,
+                            filter: {
+                                equals: {
+                                    collectionId: collectionId ? collectionId : ''
+                                }
+                            }
+                        }
                     })
                 );
                 closeDialog();

--- a/runbotics/runbotics-orchestrator-ui/src/src-app/views/credentials/GridView/CredentialsGridView/CredentialModals.tsx
+++ b/runbotics/runbotics-orchestrator-ui/src/src-app/views/credentials/GridView/CredentialsGridView/CredentialModals.tsx
@@ -58,8 +58,12 @@ export const CredentialsModals: FC<CredentialsModalsProps> = ({
 
                 dispatch(
                     credentialsActions.fetchAllCredentialsAccessibleInTenantByPage({
-                        pageParams: { page: 0, pageSize },
-                    })
+                        pageParams: { page: 0, pageSize,
+                            filter: {
+                                equals: {
+                                    collectionId: collectionId ? collectionId : ''}
+                            }
+                        }})
                 );
             })
             .catch(error => {

--- a/runbotics/runbotics-scheduler/package.json
+++ b/runbotics/runbotics-scheduler/package.json
@@ -1,6 +1,6 @@
 {
     "name": "runbotics-scheduler",
-    "version": "2.11.0-SNAPSHOT.119",
+    "version": "2.11.0-SNAPSHOT.120",
     "author": {
         "name": "runbotics",
         "email": "contact@runbotics.com"

--- a/runbotics/runbotics-scheduler/package.json
+++ b/runbotics/runbotics-scheduler/package.json
@@ -1,6 +1,6 @@
 {
     "name": "runbotics-scheduler",
-    "version": "2.11.0-SNAPSHOT.121",
+    "version": "2.11.0-SNAPSHOT.122",
     "author": {
         "name": "runbotics",
         "email": "contact@runbotics.com"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above (if possible start with issue number with # prefix) -->
<!--- Example: #123 - Some description -->

## Description

- Fixes issue when user with read only access to collection could initially input attribute value in edit credential view
- Fixes issue with credential tile, when it was clickable only on the content (now - you can click anywhere in the card)
- Adds 404 redirect in case we provide URL for credential that doesn't exist or the user do not have access to this
- Fixes issue when on credential deletion in collection view user got all credentials listed instead of credential in the collection
- Minor attribute cards styling update


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

---

I agree to the terms of the RunBotics Contributor License Agreement.