### PR TITLE
[RPA-2173] Implemented CustomSelectField and BasicSelectField

### DIFF
--- a/runbotics/common/config/runbotics.json
+++ b/runbotics/common/config/runbotics.json
@@ -1,3 +1,3 @@
 {
-    "version": "3.2.0-SNAPSHOT.21"
+    "version": "3.2.0-SNAPSHOT.22"
 }

--- a/runbotics/runbotics-desktop/package.json
+++ b/runbotics/runbotics-desktop/package.json
@@ -1,6 +1,6 @@
 {
     "name": "runbotics-desktop",
-    "version": "3.2.0-SNAPSHOT.21",
+    "version": "3.2.0-SNAPSHOT.22",
     "author": {
         "name": "runbotics",
         "email": "contact@runbotics.com"

--- a/runbotics/runbotics-orchestrator-ui/package.json
+++ b/runbotics/runbotics-orchestrator-ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "runbotics-orchestrator-ui",
-    "version": "3.2.0-SNAPSHOT.21",
+    "version": "3.2.0-SNAPSHOT.22",
     "author": {
         "name": "runbotics",
         "email": "contact@runbotics.com"

--- a/runbotics/runbotics-orchestrator-ui/src/src-app/Actions/file.actions.ts
+++ b/runbotics/runbotics-orchestrator-ui/src/src-app/Actions/file.actions.ts
@@ -102,6 +102,11 @@ const getFileActions = (): Record<string, IBpmnAction> => ({
             uiSchema: {
                 'ui:order': ['input', 'output'],
                 input: {
+                    path: {
+                        'ui:options': {
+                            info: translate('Process.Details.Modeler.Actions.File.CreateFile.FilePathInfo'),
+                        },
+                    },
                     conflict: {
                         'ui:options': {
                             info: translate('Process.Details.Modeler.Actions.File.CreateFile.ConflictInfo'),

--- a/runbotics/runbotics-orchestrator-ui/src/src-app/Actions/file.actions.ts
+++ b/runbotics/runbotics-orchestrator-ui/src/src-app/Actions/file.actions.ts
@@ -101,9 +101,13 @@ const getFileActions = (): Record<string, IBpmnAction> => ({
             },
             uiSchema: {
                 'ui:order': ['input', 'output'],
-                conflict: {
-                    'ui:widget': 'radio',
-                },
+                input: {
+                    conflict: {
+                        'ui:options': {
+                            info: translate('Process.Details.Modeler.Actions.File.CreateFile.ConflictInfo'),
+                        },
+                    },
+                }
             },
             formData: {
                 input: {

--- a/runbotics/runbotics-orchestrator-ui/src/src-app/translations/en/process/process.json
+++ b/runbotics/runbotics-orchestrator-ui/src/src-app/translations/en/process/process.json
@@ -260,6 +260,7 @@
     "Process.Details.Modeler.Actions.File.CreateFile.Label": "Create",
     "Process.Details.Modeler.Actions.File.CreateFile.FilePath": "File path (e.g. C://RunBotics/example.txt)",
     "Process.Details.Modeler.Actions.File.CreateFile.Conflict": "Conflict",
+    "Process.Details.Modeler.Actions.File.CreateFile.ConflictInfo": "To resolve a file conflict when a file already exists, you can handle the error, overwrite the existing file, or save the new file with a different name.",
     "Process.Details.Modeler.Actions.File.RemoveFile.Label": "Remove",
     "Process.Details.Modeler.Actions.File.RemoveFile.FilePath": "File path (e.g. C://RunBotics/example.txt)",
     "Process.Details.Modeler.Actions.File.ReadFile.Label": "Read",

--- a/runbotics/runbotics-orchestrator-ui/src/src-app/translations/en/process/process.json
+++ b/runbotics/runbotics-orchestrator-ui/src/src-app/translations/en/process/process.json
@@ -259,6 +259,7 @@
     "Process.Details.Modeler.Actions.File.AppendFile.Separator": "Separator(;)",
     "Process.Details.Modeler.Actions.File.CreateFile.Label": "Create",
     "Process.Details.Modeler.Actions.File.CreateFile.FilePath": "File path (e.g. C://RunBotics/example.txt)",
+    "Process.Details.Modeler.Actions.File.CreateFile.FilePathInfo": "Path to file where it will be created (e.g. C://RunBotics/example.txt)",
     "Process.Details.Modeler.Actions.File.CreateFile.Conflict": "Conflict",
     "Process.Details.Modeler.Actions.File.CreateFile.ConflictInfo": "To resolve a file conflict when a file already exists, you can handle the error, overwrite the existing file, or save the new file with a different name.",
     "Process.Details.Modeler.Actions.File.RemoveFile.Label": "Remove",

--- a/runbotics/runbotics-orchestrator-ui/src/src-app/translations/pl/process/process.json
+++ b/runbotics/runbotics-orchestrator-ui/src/src-app/translations/pl/process/process.json
@@ -258,6 +258,7 @@
     "Process.Details.Modeler.Actions.File.AppendFile.Separator": "Separator(;)",
     "Process.Details.Modeler.Actions.File.CreateFile.Label": "Utwórz",
     "Process.Details.Modeler.Actions.File.CreateFile.FilePath": "Ścieżka pliku (np. C://RunBotics/example.txt)",
+    "Process.Details.Modeler.Actions.File.CreateFile.FilePathInfo": "Ścieżka do pliku, który ma być utworzony (np. C://RunBotics/example.txt)",
     "Process.Details.Modeler.Actions.File.CreateFile.Conflict": "Konflikt nazewnictwa",
     "Process.Details.Modeler.Actions.File.CreateFile.ConflictInfo": "Aby rozwiązać konflikt plików, gdy plik już istnieje, możesz obsłużyć błąd, nadpisać istniejący plik lub zapisać nowy plik pod inną nazwą.",
     "Process.Details.Modeler.Actions.File.RemoveFile.Label": "Usuń",

--- a/runbotics/runbotics-orchestrator-ui/src/src-app/translations/pl/process/process.json
+++ b/runbotics/runbotics-orchestrator-ui/src/src-app/translations/pl/process/process.json
@@ -259,6 +259,7 @@
     "Process.Details.Modeler.Actions.File.CreateFile.Label": "Utwórz",
     "Process.Details.Modeler.Actions.File.CreateFile.FilePath": "Ścieżka pliku (np. C://RunBotics/example.txt)",
     "Process.Details.Modeler.Actions.File.CreateFile.Conflict": "Konflikt nazewnictwa",
+    "Process.Details.Modeler.Actions.File.CreateFile.ConflictInfo": "Aby rozwiązać konflikt plików, gdy plik już istnieje, możesz obsłużyć błąd, nadpisać istniejący plik lub zapisać nowy plik pod inną nazwą.",
     "Process.Details.Modeler.Actions.File.RemoveFile.Label": "Usuń",
     "Process.Details.Modeler.Actions.File.RemoveFile.FilePath": "Ścieżka pliku (np. C://RunBotics/example.txt)",
     "Process.Details.Modeler.Actions.File.ReadFile.Label": "Odczytaj",

--- a/runbotics/runbotics-orchestrator-ui/src/src-app/views/process/ProcessBuildView/Modeler/ActionFormPanel/widgets/CustomSelectWidget.tsx
+++ b/runbotics/runbotics-orchestrator-ui/src/src-app/views/process/ProcessBuildView/Modeler/ActionFormPanel/widgets/CustomSelectWidget.tsx
@@ -1,0 +1,23 @@
+import React, { FC } from 'react';
+
+import { WidgetProps } from '@rjsf/core';
+import styled from 'styled-components';
+
+import BasicSelectField from './components/BasicSelectField';
+
+
+const TestFiledWrapper = styled.div`
+    display: flex;
+    width: 100%;
+    align-items: center;
+`;
+
+const CustomSelectWidget: FC<WidgetProps> = (props) => (
+    <TestFiledWrapper>
+        <BasicSelectField
+            {...props}
+        />
+    </TestFiledWrapper>
+);
+
+export default CustomSelectWidget;

--- a/runbotics/runbotics-orchestrator-ui/src/src-app/views/process/ProcessBuildView/Modeler/ActionFormPanel/widgets/components/BasicSelectField.tsx
+++ b/runbotics/runbotics-orchestrator-ui/src/src-app/views/process/ProcessBuildView/Modeler/ActionFormPanel/widgets/components/BasicSelectField.tsx
@@ -1,0 +1,88 @@
+import React, { FC, useMemo } from 'react';
+
+import { AutocompleteRenderInputParams, MenuItem, TextField } from '@mui/material';
+import { WidgetProps } from '@rjsf/core';
+
+import If from '#src-app/components/utils/If';
+
+import { useSelector } from '#src-app/store';
+
+import { TooltipTextFieldWrapper } from '#src-app/views/process/ProcessBuildView/Modeler/ActionFormPanel/widgets/InfoTooltip/InfoButtonTooltip.styles';
+
+import { BPMNElement } from '../../../helpers/elementParameters';
+import InfoButtonTooltip from '../InfoTooltip/InfoButtonTooltip';
+
+interface BasicSelectFieldProps extends WidgetProps {
+    params?: AutocompleteRenderInputParams;
+    options: {
+        info?: string;
+    };
+    customErrors?: string[];
+    formContext: {
+        selectedElement: BPMNElement;
+    };
+}
+
+const BasicSelectField: FC<BasicSelectFieldProps> = ({
+    params = {},
+    onChange,
+    formContext: { selectedElement },
+    ...props
+}) => {
+    const { customValidationErrors } = useSelector(
+        (state) => state.process.modeler
+    );
+    const currentValue = props.value || '';
+    const errors = props.customErrors;
+
+    const isFieldDisabled = useMemo(() => {
+        if (customValidationErrors.length > 0) {
+            const erroredElement = customValidationErrors.find(
+                (error) => error.elementId !== selectedElement.id
+            );
+            return Boolean(erroredElement);
+        }
+        return false;
+    }, [selectedElement, customValidationErrors]);
+
+    const handleChange = (newValue: string | undefined) => {
+        onChange(newValue || undefined);
+    };
+
+    const choices = useMemo(() => (props.schema.enum ?? [])
+        .filter(choice => {
+            if (typeof choice !== 'string' && typeof choice !== 'number') {
+                // eslint-disable-next-line no-console
+                console.warn(`Any non string or number value is not supported as enum key; Got: ${choice} TYPE: ${typeof choice}`);
+                return false;
+            }
+
+            return true;
+        })
+        .map(choice => choice.toString()), [props.schema.enum]
+    );
+
+    return (
+        <TooltipTextFieldWrapper>
+            <TextField
+                {...params}
+                value={currentValue}
+                fullWidth
+                variant="outlined"
+                disabled={isFieldDisabled}
+                required={props.required}
+                label={props.label}
+                select
+                onChange={(event) => handleChange(event.target.value)}
+                error={Boolean(errors) || Boolean(props.rawErrors)}
+            >
+                {choices.map(choice => <MenuItem key={choice} value={choice}>{choice}</MenuItem>)}
+            </TextField>
+            <If condition={Boolean(props.options?.info)}>
+                <InfoButtonTooltip message={props.options?.info} />
+            </If>
+        </TooltipTextFieldWrapper>
+    );
+};
+
+export default BasicSelectField;

--- a/runbotics/runbotics-orchestrator-ui/src/src-app/views/process/ProcessBuildView/Modeler/ActionFormPanel/widgets/index.tsx
+++ b/runbotics/runbotics-orchestrator-ui/src/src-app/views/process/ProcessBuildView/Modeler/ActionFormPanel/widgets/index.tsx
@@ -11,6 +11,7 @@ const BrowserTargetWidget = dynamic(() => import('./BrowserTargetWidget'), { ssr
 const TypographyWidget = dynamic(() => import('./TypographyWidget'), { ssr: false });
 const DatePickerWidget = dynamic(() => import('./DatePickerWidget'), { ssr: false });
 const CredentialWidget = dynamic(() => import('./CredentialWidget/CredentialWidget'), { ssr: false });
+const CustomSelectWidget = dynamic(() => import('./CustomSelectWidget'), { ssr: false });
 
 const customWidgets = {
     TextWidget: CustomTextWidget,
@@ -24,6 +25,7 @@ const customWidgets = {
     TypographyWidget,
     DatePickerWidget,
     CredentialWidget,
+    SelectWidget: CustomSelectWidget,
 };
 
 export default customWidgets;

--- a/runbotics/runbotics-scheduler/package.json
+++ b/runbotics/runbotics-scheduler/package.json
@@ -1,6 +1,6 @@
 {
     "name": "runbotics-scheduler",
-    "version": "3.2.0-SNAPSHOT.21",
+    "version": "3.2.0-SNAPSHOT.22",
     "author": {
         "name": "runbotics",
         "email": "contact@runbotics.com"


### PR DESCRIPTION
In order to facilitate adding tooltips on fields defined with `enum` properties.

Previously - no tooltips:
![image](https://github.com/user-attachments/assets/9ca9d482-d7fe-4f53-93c6-74404004b630)

Now:
![image](https://github.com/user-attachments/assets/d4ef7439-fcc1-4310-bac7-969203e23b2f)

<!--- Provide a general summary of your changes in the Title above (if possible start with issue number with # prefix) -->
<!--- Example: #123 - Some description -->

## Description

<!--- Describe your changes in detail, provide screenshots if necessary -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

---

I agree to the terms of the RunBotics Contributor License Agreement.