### PR TITLE
[RPA-2015] Fix issue where action which uses credential couldn't be removed without choosing credential

### DIFF
--- a/runbotics-orchestrator/build.gradle
+++ b/runbotics-orchestrator/build.gradle
@@ -27,7 +27,7 @@ plugins {
 group = "com.runbotics"
 
 
-version = "3.2.0-SNAPSHOT.18"
+version = "3.2.0-SNAPSHOT.19"
 
 description = ""
 

--- a/runbotics/common/config/runbotics.json
+++ b/runbotics/common/config/runbotics.json
@@ -1,3 +1,3 @@
 {
-    "version": "3.2.0-SNAPSHOT.18"
+    "version": "3.2.0-SNAPSHOT.19"
 }

--- a/runbotics/runbotics-desktop/package.json
+++ b/runbotics/runbotics-desktop/package.json
@@ -1,6 +1,6 @@
 {
     "name": "runbotics-desktop",
-    "version": "3.2.0-SNAPSHOT.18",
+    "version": "3.2.0-SNAPSHOT.19",
     "author": {
         "name": "runbotics",
         "email": "contact@runbotics.com"

--- a/runbotics/runbotics-orchestrator-ui/package.json
+++ b/runbotics/runbotics-orchestrator-ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "runbotics-orchestrator-ui",
-    "version": "3.2.0-SNAPSHOT.18",
+    "version": "3.2.0-SNAPSHOT.19",
     "author": {
         "name": "runbotics",
         "email": "contact@runbotics.com"

--- a/runbotics/runbotics-orchestrator-ui/src/src-app/views/process/ProcessBuildView/Modeler/BpmnModeler/BpmnModeler.tsx
+++ b/runbotics/runbotics-orchestrator-ui/src/src-app/views/process/ProcessBuildView/Modeler/BpmnModeler/BpmnModeler.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useImperativeHandle, useState } from 'react';
 
 import 'bpmn-js/dist/assets/diagram-js.css';
 import 'bpmn-js/dist/assets/bpmn-font/css/bpmn-embedded.css';
-import { PayloadAction } from '@reduxjs/toolkit';
 import BpmnIoModeler from 'bpmn-js/lib/Modeler';
 import 'bpmn-js-properties-panel/dist/assets/bpmn-js-properties-panel.css';
 import i18n from 'i18next';
@@ -15,7 +14,6 @@ import 'react-resizable/css/styles.css';
 import InfoPanel from '#src-app/components/InfoPanel';
 import VariablesPanel from '#src-app/components/ProcessVariablesPanel/VariablesPanel';
 import ResizableDrawer from '#src-app/components/ResizableDrawer';
-import useCustomValidation from '#src-app/hooks/useCustomValidation';
 import useModelerListener, {
     isModelerSync,
 } from '#src-app/hooks/useModelerListener';
@@ -24,14 +22,10 @@ import useTranslations from '#src-app/hooks/useTranslations';
 import useUpdateEffect from '#src-app/hooks/useUpdateEffect';
 import ModelerProvider from '#src-app/providers/ModelerProvider';
 import { useDispatch, useSelector } from '#src-app/store';
-import { credentialsActions, credentialsSelector } from '#src-app/store/slices/Credentials';
 import {
     CommandStackInfo,
-    ModelerError,
-    ModelerErrorType,
     processActions,
     processSelector,
-    ProcessState,
 } from '#src-app/store/slices/Process';
 import { processInstanceSelector } from '#src-app/store/slices/ProcessInstance';
 import { ProcessBuildTab } from '#src-app/types/sidebar';
@@ -46,7 +40,6 @@ import {
     ModelerProps,
     initializeBpmnDiagram,
     Wrapper,
-    setNoCredentialsSpecifiedError,
 } from '.';
 import { getBpmnModelerConfig } from './BpmnModeler.config';
 import ImportExportPanel from '../../ModelerPanels/ImportExportPanel';
@@ -217,11 +210,6 @@ const BpmnModeler = React.forwardRef<ModelerImperativeHandle, ModelerProps>(
         useEffect(() => {
             modelerRef.current = modeler;
         }, [modeler, offsetTop]);
-
-        useEffect(() => {
-            setNoCredentialsSpecifiedError(dispatch, definition, coveredCredentialTypes);
-            // eslint-disable-next-line react-hooks/exhaustive-deps
-        }, [definition, coveredCredentialTypes]);
 
         const handleSave = () => {
             recordItemClick({ itemName: CLICKABLE_ITEM.SAVE_BUTTON, sourcePage: identifyPageByUrl(pathname) });

--- a/runbotics/runbotics-orchestrator-ui/src/src-app/views/process/ProcessBuildView/Modeler/BpmnModeler/BpmnModeler.utils.ts
+++ b/runbotics/runbotics-orchestrator-ui/src/src-app/views/process/ProcessBuildView/Modeler/BpmnModeler/BpmnModeler.utils.ts
@@ -1,9 +1,6 @@
-import { AnyAction, Dispatch, PayloadAction } from '@reduxjs/toolkit';
 import BpmnIoModeler from 'bpmn-js/lib/Modeler';
 import _ from 'lodash';
-import { ActionCredentialType } from 'runbotics-common';
 
-import { ModelerError, ModelerErrorType, processActions } from '#src-app/store/slices/Process';
 
 import {
     ModelerHTMLCanvasElement,
@@ -210,31 +207,4 @@ export const retrieveGlobalVariableIds = (modeler: BpmnIoModeler): string[] => {
         .map((item) => item.value);
 
     return Array.from(new Set(allGlobalVariableIds));
-};
-
-export const setNoCredentialsSpecifiedError = (dispatch: Dispatch<AnyAction>, definition: string, coveredCredentialTypes: ActionCredentialType[]): void => {
-    const actionCredentialPairs = [];
-    const regex = /camunda:actionId="([^"]+)".+camunda:credentialType="([^"]+)"/g;
-
-    const matches = definition.matchAll(regex);
-    Array.from(matches).forEach(match => {
-        const credentialType = match[2] as ActionCredentialType;
-        if (coveredCredentialTypes.includes(credentialType)) return;
-        actionCredentialPairs.push({
-            actionId: match[1],
-        });
-    });
-
-    for (const pair of actionCredentialPairs) {
-        const { actionId } = pair;
-        const action: PayloadAction<ModelerError> = {
-            payload: {
-                elementName: actionId,
-                elementId: actionId,
-                type: ModelerErrorType.FORM_ERROR,
-            },
-            type: 'fulfilled',
-        };
-        dispatch(processActions.setError(action.payload));
-    }
 };

--- a/runbotics/runbotics-scheduler/package.json
+++ b/runbotics/runbotics-scheduler/package.json
@@ -1,6 +1,6 @@
 {
     "name": "runbotics-scheduler",
-    "version": "3.2.0-SNAPSHOT.18",
+    "version": "3.2.0-SNAPSHOT.19",
     "author": {
         "name": "runbotics",
         "email": "contact@runbotics.com"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above (if possible start with issue number with # prefix) -->
<!--- Example: #123 - Some description -->

## Description

Removing the check that credentials were entered before saving. Previously, it worked in such a way that if we wanted to enter credentials before saving, we deleted the actions. Currently we can save, go to configure and fill in the needed information, then we can delete the action if it is not needed.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

---

I agree to the terms of the RunBotics Contributor License Agreement.