### PR TITLE
[RPA-2118] Refactored version bumping so it's done by node rather than gradle

### DIFF
--- a/runbotics-orchestrator/build.gradle
+++ b/runbotics-orchestrator/build.gradle
@@ -86,17 +86,6 @@ springBoot {
     mainClassName = "com.runbotics.RunboticsApp"
 }
 
-task setVersion {
-    doLast {
-        group = 'Versioning'
-        description = "Sets the version to the specified parameter -PnewVersion=\'x.x.x\'"
-        if(project.hasProperty('newVersion')) {
-            String s=buildFile.getText().replaceFirst(/version = \".+\"/, "version = \"" + newVersion + "\"")
-            buildFile.setText(s)
-        }
-    }
-}
-
 test {
     useJUnitPlatform()
     exclude "**/*IT*", "**/*IntTest*"

--- a/runbotics/runbotics-cli/package.json
+++ b/runbotics/runbotics-cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@runbotics/runbotics-cli",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "license": "MIT",
     "author": {
         "name": "runbotics",

--- a/runbotics/runbotics-cli/src/commands/version/alter-files.ts
+++ b/runbotics/runbotics-cli/src/commands/version/alter-files.ts
@@ -32,11 +32,13 @@ const alterFiles = async (rbRootDir: string, newVersion: string) => {
         {
             title: 'orchestrator',
             task: async () => {
-                try {
-                    await spawn('sh', ['gradlew', 'setVersion', `-PnewVersion=${newVersion}`], { cwd: join(rbRootDir, 'runbotics-orchestrator') });
-                } catch (e: any) {
-                    throw new Error(chalk.red(`${Emoji.error} Error: Could not overwrite orchestrator config version`));
-                }
+                const absolutePath = join(rbRootDir, 'runbotics-orchestrator/build.gradle');
+
+                const file = fs.readFileSync(absolutePath, 'utf-8');
+
+                const expr = /version = ".+"/;
+                const newFile = file.replace(expr, 'version = "' + newVersion + '"');
+                fs.writeFileSync(absolutePath, newFile, { encoding: 'utf-8' });
             },
         },
         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above (if possible start with issue number with # prefix) -->
<!--- Example: #123 - Some description -->

## Description

Previously it was gradle.build task doing that, now it's JS, so that gradlew is not needed to do version bump.

<!--- Describe your changes in detail, provide screenshots if necessary -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

---

I agree to the terms of the RunBotics Contributor License Agreement.