### PR TITLE
[RPA-2412] Bump version to sync changes from gitea

### DIFF
--- a/runbotics-orchestrator/build.gradle
+++ b/runbotics-orchestrator/build.gradle
@@ -27,7 +27,7 @@ plugins {
 group = "com.runbotics"
 
 
-version = "3.5.0-SNAPSHOT.24"
+version = "3.5.0-SNAPSHOT.32"
 description = ""
 
 sourceCompatibility=11

--- a/runbotics/common/config/runbotics.json
+++ b/runbotics/common/config/runbotics.json
@@ -1,3 +1,3 @@
 {
-    "version": "3.5.0-SNAPSHOT.24"
+    "version": "3.5.0-SNAPSHOT.32"
 }

--- a/runbotics/runbotics-desktop/package.json
+++ b/runbotics/runbotics-desktop/package.json
@@ -1,6 +1,6 @@
 {
     "name": "runbotics-desktop",
-    "version": "3.5.0-SNAPSHOT.24",
+    "version": "3.5.0-SNAPSHOT.32",
     "author": {
         "name": "runbotics",
         "email": "contact@runbotics.com"

--- a/runbotics/runbotics-lp/package.json
+++ b/runbotics/runbotics-lp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "runbotics-lp",
-    "version": "3.5.0-SNAPSHOT.24",
+    "version": "3.5.0-SNAPSHOT.32",
     "private": true,
     "scripts": {
         "dev": "next dev -p 3001",

--- a/runbotics/runbotics-orchestrator-ui/package.json
+++ b/runbotics/runbotics-orchestrator-ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "runbotics-orchestrator-ui",
-    "version": "3.5.0-SNAPSHOT.24",
+    "version": "3.5.0-SNAPSHOT.32",
     "author": {
         "name": "runbotics",
         "email": "contact@runbotics.com"

--- a/runbotics/runbotics-scheduler/package.json
+++ b/runbotics/runbotics-scheduler/package.json
@@ -1,6 +1,6 @@
 {
     "name": "runbotics-scheduler",
-    "version": "3.5.0-SNAPSHOT.24",
+    "version": "3.5.0-SNAPSHOT.32",
     "author": {
         "name": "runbotics",
         "email": "contact@runbotics.com"


### PR DESCRIPTION
On the gitea side, there were some version bumps, which were required in order to trigger auto deployment there.

Since these versions were pushed to docker registry, a new version bump is required here on GH.

Note that all changes from gitea can't be just ported to GH, since these include changes to GH actions/workflows, which in turn would break them on github, as they were adapted for gitea.