### PR TITLE
[RPA-2465] Hide login button for standalone lp-only deployments

### DIFF
--- a/runbotics/runbotics-lp/next.config.js
+++ b/runbotics/runbotics-lp/next.config.js
@@ -23,6 +23,7 @@ const nextConfig = {
         mixpanelAnalyticsToken: process.env.MIXPANEL_ANALYTICS_TOKEN,
         copilotChatUrl: process.env.COPILOT_CHAT_URL,
         isSsoEnabled: process.env.IS_SSO_ENABLED,
+        isRunboticsLpOnly: process.env.IS_RUNBOTICS_LP_ONLY || false,
     },
 
     serverRuntimeConfig: {

--- a/runbotics/runbotics-lp/src/src-landing/components/Header/LoginLink/LoginLink.module.scss
+++ b/runbotics/runbotics-lp/src/src-landing/components/Header/LoginLink/LoginLink.module.scss
@@ -8,3 +8,7 @@
 .linkText {
     font-weight: $font-weight-semi-bold;
 }
+
+.space {
+    padding: 1rem;
+}

--- a/runbotics/runbotics-lp/src/src-landing/components/Header/LoginLink/LoginLink.tsx
+++ b/runbotics/runbotics-lp/src/src-landing/components/Header/LoginLink/LoginLink.tsx
@@ -1,10 +1,13 @@
 import type { VFC } from 'react';
 
+import getConfig from 'next/config';
+
+import styles from './LoginLink.module.scss';
+
 import { useLocalizedUrl } from '#src-app/hooks/useLocalization';
 import useTranslations from '#src-app/hooks/useTranslations';
 import Typography from '#src-landing/components/Typography';
 
-import styles from './LoginLink.module.scss';
 
 interface Props {
     className?: string;
@@ -13,6 +16,11 @@ interface Props {
 const LoginLink: VFC<Props> = ({ className }) => {
     const { translate } = useTranslations();
     const { getLocalizedUrl } = useLocalizedUrl();
+    const { publicRuntimeConfig } = getConfig();
+
+    if (publicRuntimeConfig.isRunboticsLpOnly === 'true') {
+        return <div className={styles.space}></div>;
+    }
 
     return (
         <a className={`${styles.link} ${className}`} href={getLocalizedUrl('/login')}>

--- a/runbotics/runbotics-lp/src/src-landing/components/Header/LoginLink/LoginLink.tsx
+++ b/runbotics/runbotics-lp/src/src-landing/components/Header/LoginLink/LoginLink.tsx
@@ -2,12 +2,11 @@ import type { VFC } from 'react';
 
 import getConfig from 'next/config';
 
-import styles from './LoginLink.module.scss';
-
 import { useLocalizedUrl } from '#src-app/hooks/useLocalization';
 import useTranslations from '#src-app/hooks/useTranslations';
 import Typography from '#src-landing/components/Typography';
 
+import styles from './LoginLink.module.scss';
 
 interface Props {
     className?: string;


### PR DESCRIPTION
Result:
<img width="164" height="61" alt="image" src="https://github.com/user-attachments/assets/b19e5c9e-2752-4cc9-ac7c-babc9f897a07" />
This is so that we can deploy lp as standalone entity.

<!--- Provide a general summary of your changes in the Title above (if possible start with issue number with # prefix) -->
<!--- Example: #123 - Some description -->

## Description

<!--- Describe your changes in detail, provide screenshots if necessary -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

---

I agree to the terms of the RunBotics Contributor License Agreement.