### PR TITLE
[RPA-2532] Prevent scheduler from OOMing on a process using loop with 1000+ iterations

### DIFF
--- a/runbotics-orchestrator/build.gradle
+++ b/runbotics-orchestrator/build.gradle
@@ -27,7 +27,7 @@ plugins {
 group = "com.runbotics"
 
 
-version = "3.6.0-SNAPSHOT.0"
+version = "3.6.0-SNAPSHOT.1"
 description = ""
 
 sourceCompatibility=11

--- a/runbotics/common/config/runbotics.json
+++ b/runbotics/common/config/runbotics.json
@@ -1,3 +1,3 @@
 {
-    "version": "3.6.0-SNAPSHOT.0"
+    "version": "3.6.0-SNAPSHOT.1"
 }

--- a/runbotics/runbotics-desktop/package.json
+++ b/runbotics/runbotics-desktop/package.json
@@ -1,6 +1,6 @@
 {
     "name": "runbotics-desktop",
-    "version": "3.6.0-SNAPSHOT.0",
+    "version": "3.6.0-SNAPSHOT.1",
     "author": {
         "name": "runbotics",
         "email": "contact@runbotics.com"

--- a/runbotics/runbotics-lp/package.json
+++ b/runbotics/runbotics-lp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "runbotics-lp",
-    "version": "3.6.0-SNAPSHOT.0",
+    "version": "3.6.0-SNAPSHOT.1",
     "private": true,
     "scripts": {
         "dev": "next dev -p 3001",

--- a/runbotics/runbotics-orchestrator-ui/package.json
+++ b/runbotics/runbotics-orchestrator-ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "runbotics-orchestrator-ui",
-    "version": "3.6.0-SNAPSHOT.0",
+    "version": "3.6.0-SNAPSHOT.1",
     "author": {
         "name": "runbotics",
         "email": "contact@runbotics.com"

--- a/runbotics/runbotics-scheduler/package.json
+++ b/runbotics/runbotics-scheduler/package.json
@@ -1,6 +1,6 @@
 {
     "name": "runbotics-scheduler",
-    "version": "3.6.0-SNAPSHOT.0",
+    "version": "3.6.0-SNAPSHOT.1",
     "author": {
         "name": "runbotics",
         "email": "contact@runbotics.com"

--- a/runbotics/runbotics-scheduler/src/auth/guards/featureKey.guard.ts
+++ b/runbotics/runbotics-scheduler/src/auth/guards/featureKey.guard.ts
@@ -25,7 +25,9 @@ export class FeatureKeyGuard extends JwtAuthGuard {
         const request = context.switchToHttp().getRequest<AuthRequest>();
         const user = request.user;
 
-        return hasFeatureKeys(user, featureKeys);
+        const hasKeys = hasFeatureKeys(user, featureKeys);
+
+        return hasKeys;
     
     }
 }

--- a/runbotics/runbotics-scheduler/src/auth/guards/featureKey.guard.ts
+++ b/runbotics/runbotics-scheduler/src/auth/guards/featureKey.guard.ts
@@ -25,9 +25,7 @@ export class FeatureKeyGuard extends JwtAuthGuard {
         const request = context.switchToHttp().getRequest<AuthRequest>();
         const user = request.user;
 
-        const hasKeys = hasFeatureKeys(user, featureKeys);
-
-        return hasKeys;
+        return hasFeatureKeys(user, featureKeys);
     
     }
 }

--- a/runbotics/runbotics-scheduler/src/queue/bot/bot.controller.ts
+++ b/runbotics/runbotics-scheduler/src/queue/bot/bot.controller.ts
@@ -95,7 +95,7 @@ export class BotController {
         const botProcessInstances =
             await this.processInstanceService.findAllByBotId(id, user.tenantId);
 
-        botProcessInstances.forEach(async (instance) => {
+        for (const instance of botProcessInstances) {
             if (
                 instance.status === ProcessInstanceStatus.IN_PROGRESS ||
                 instance.status === ProcessInstanceStatus.INITIALIZING
@@ -103,7 +103,7 @@ export class BotController {
                 instance.status = ProcessInstanceStatus.TERMINATED;
                 await this.processInstanceService.create(instance);
             }
-        });
+        }
 
         return await this.botSchedulerService.deleteById(bot).catch((err) => {
             this.logger.log(`<= Bot ${id} deletion failed`);

--- a/runbotics/runbotics-scheduler/src/utils/semaphore.spec.ts
+++ b/runbotics/runbotics-scheduler/src/utils/semaphore.spec.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Semaphore } from './semaphore';
+
+describe('Semaphore', () => {
+    let semaphore: Semaphore;
+
+    beforeEach(() => {
+        semaphore = new Semaphore(2);
+    });
+
+    describe('basic acquire/release', () => {
+        it('should allow acquiring up to max permits', async () => {
+            await semaphore.acquire();
+            await semaphore.acquire();
+            
+            expect(semaphore.available()).toBe(0);
+            expect(semaphore.waitingCount()).toBe(0);
+        });
+
+        it('should queue when permits exhausted', async () => {
+            await semaphore.acquire();
+            await semaphore.acquire();
+            
+            const acquirePromise = semaphore.acquire();
+            
+            expect(semaphore.available()).toBe(0);
+            expect(semaphore.waitingCount()).toBe(1);
+            
+            semaphore.release();
+            await acquirePromise;
+            
+            expect(semaphore.available()).toBe(0);
+            expect(semaphore.waitingCount()).toBe(0);
+        });
+
+        it('should release permits back when not waiting', () => {
+            semaphore.release();
+            
+            expect(semaphore.available()).toBe(2);
+        });
+
+        it('should not exceed max permits on release', () => {
+            semaphore.release();
+            semaphore.release();
+            semaphore.release();
+            
+            expect(semaphore.available()).toBe(2);
+        });
+    });
+
+    describe('concurrent operations', () => {
+        it('should handle multiple acquisitions in order', async () => {
+            const semaphore = new Semaphore(1);
+            const results: number[] = [];
+            
+            const task = async (id: number) => {
+                await semaphore.acquire();
+                results.push(id);
+                await new Promise(resolve => setTimeout(resolve, 10));
+                semaphore.release();
+            };
+            
+            await Promise.all([task(1), task(2), task(3)]);
+            
+            expect(results).toHaveLength(3);
+            expect(results).toEqual([1, 2, 3]);
+        });
+
+        it('should allow parallel execution up to limit', async () => {
+            const semaphore = new Semaphore(3);
+            let concurrent = 0;
+            let maxConcurrent = 0;
+            
+            const task = async () => {
+                await semaphore.acquire();
+                concurrent++;
+                maxConcurrent = Math.max(maxConcurrent, concurrent);
+                await new Promise(resolve => setTimeout(resolve, 20));
+                concurrent--;
+                semaphore.release();
+            };
+            
+            await Promise.all([task(), task(), task(), task(), task()]);
+            
+            expect(maxConcurrent).toBe(3);
+            expect(concurrent).toBe(0);
+        });
+    });
+
+    describe('dynamic permit changes', () => {
+        it('should increase permits and wake waiting tasks', async () => {
+            await semaphore.acquire();
+            await semaphore.acquire();
+            
+            const promise1 = semaphore.acquire();
+            const promise2 = semaphore.acquire();
+            
+            expect(semaphore.waitingCount()).toBe(2);
+            
+            semaphore.setMaxPermits(4);
+            
+            await promise1;
+            await promise2;
+            
+            expect(semaphore.waitingCount()).toBe(0);
+            expect(semaphore.getMaxPermits()).toBe(4);
+        });
+
+        it('should decrease permits', () => {
+            semaphore.setMaxPermits(1);
+            
+            expect(semaphore.getMaxPermits()).toBe(1);
+            expect(semaphore.available()).toBe(1);
+        });
+
+        it('should enforce minimum of 1 permit', () => {
+            semaphore.setMaxPermits(0);
+            expect(semaphore.getMaxPermits()).toBe(1);
+            
+            semaphore.setMaxPermits(-5);
+            expect(semaphore.getMaxPermits()).toBe(1);
+        });
+    });
+
+    describe('edge cases', () => {
+        it('should handle initialization with invalid permits', () => {
+            const sem1 = new Semaphore(0);
+            expect(sem1.getMaxPermits()).toBe(1);
+            
+            const sem2 = new Semaphore(-10);
+            expect(sem2.getMaxPermits()).toBe(1);
+        });
+
+        it('should handle rapid acquire/release cycles', async () => {
+            const semaphore = new Semaphore(1);
+            
+            for (let i = 0; i < 100; i++) {
+                await semaphore.acquire();
+                semaphore.release();
+            }
+            
+            expect(semaphore.available()).toBe(1);
+            expect(semaphore.waitingCount()).toBe(0);
+        });
+    });
+});

--- a/runbotics/runbotics-scheduler/src/utils/semaphore.ts
+++ b/runbotics/runbotics-scheduler/src/utils/semaphore.ts
@@ -1,0 +1,59 @@
+export class Semaphore {
+    private permits: number;
+    private maxPermits: number;
+    private waiting: Array<() => void> = [];
+
+    constructor(maxPermits: number) {
+        this.maxPermits = Math.max(1, maxPermits);
+        this.permits = this.maxPermits;
+    }
+
+    async acquire(): Promise<void> {
+        if (this.permits > 0) {
+            this.permits--;
+            return Promise.resolve();
+        }
+
+        return new Promise<void>((resolve) => {
+            this.waiting.push(resolve);
+        });
+    }
+
+    release(): void {
+        if (this.waiting.length > 0) {
+            const resolve = this.waiting.shift();
+            resolve?.();
+        } else {
+            this.permits = Math.min(this.permits + 1, this.maxPermits);
+        }
+    }
+
+    available(): number {
+        return this.permits;
+    }
+
+    waitingCount(): number {
+        return this.waiting.length;
+    }
+
+    setMaxPermits(maxPermits: number): void {
+        const newMax = Math.max(1, maxPermits);
+        const diff = newMax - this.maxPermits;
+        
+        if (diff > 0) {
+            for (let i = 0; i < diff && this.waiting.length > 0; i++) {
+                const resolve = this.waiting.shift();
+                resolve?.();
+            }
+            this.permits = Math.min(this.permits + diff, newMax);
+        } else if (diff < 0) {
+            this.permits = Math.max(0, this.permits + diff);
+        }
+        
+        this.maxPermits = newMax;
+    }
+
+    getMaxPermits(): number {
+        return this.maxPermits;
+    }
+}

--- a/runbotics/runbotics-scheduler/src/utils/task-queue.spec.ts
+++ b/runbotics/runbotics-scheduler/src/utils/task-queue.spec.ts
@@ -1,0 +1,358 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { TaskQueue } from './task-queue';
+
+describe('TaskQueue', () => {
+    let taskQueue: TaskQueue;
+
+    beforeEach(() => {
+        taskQueue = new TaskQueue(2);
+    });
+
+    describe('basic task execution', () => {
+        it('should execute a single task', async () => {
+            let executed = false;
+            
+            await taskQueue.enqueue(async () => {
+                executed = true;
+                return 'result';
+            });
+            
+            expect(executed).toBe(true);
+        });
+
+        it('should return the task result', async () => {
+            const result = await taskQueue.enqueue(async () => {
+                return 'test-result';
+            });
+            
+            expect(result).toBe('test-result');
+        });
+
+        it('should handle task errors', async () => {
+            const errorMessage = 'Task failed';
+            
+            await expect(
+                taskQueue.enqueue(async () => {
+                    throw new Error(errorMessage);
+                })
+            ).rejects.toThrow(errorMessage);
+        });
+    });
+
+    describe('parallelism control', () => {
+        it('should limit concurrent execution to max parallelism', async () => {
+            let concurrent = 0;
+            let maxConcurrent = 0;
+            
+            const tasks = Array.from({ length: 5 }, () =>
+                taskQueue.enqueue(async () => {
+                    concurrent++;
+                    maxConcurrent = Math.max(maxConcurrent, concurrent);
+                    await new Promise(resolve => setTimeout(resolve, 50));
+                    concurrent--;
+                })
+            );
+            
+            await Promise.all(tasks);
+            
+            expect(maxConcurrent).toBe(2);
+            expect(concurrent).toBe(0);
+        });
+
+        it('should execute tasks in FIFO order', async () => {
+            const executionOrder: number[] = [];
+            
+            const tasks = [0, 1, 2, 3, 4].map(i =>
+                taskQueue.enqueue(async () => {
+                    executionOrder.push(i);
+                    await new Promise(resolve => setTimeout(resolve, 10));
+                })
+            );
+            
+            await Promise.all(tasks);
+            
+            expect(executionOrder).toEqual([0, 1, 2, 3, 4]);
+        });
+
+        it('should handle changing max parallelism', async () => {
+            taskQueue.setMaxParallelism(3);
+            
+            let concurrent = 0;
+            let maxConcurrent = 0;
+            
+            const tasks = Array.from({ length: 6 }, () =>
+                taskQueue.enqueue(async () => {
+                    concurrent++;
+                    maxConcurrent = Math.max(maxConcurrent, concurrent);
+                    await new Promise(resolve => setTimeout(resolve, 50));
+                    concurrent--;
+                })
+            );
+            
+            await Promise.all(tasks);
+            
+            expect(maxConcurrent).toBe(3);
+        });
+    });
+
+    describe('per-bot tracking', () => {
+        it('should track tasks by bot ID', async () => {
+            const bot1Task = taskQueue.enqueue(async () => {
+                await new Promise(resolve => setTimeout(resolve, 100));
+                return 'bot1';
+            }, 'bot-1');
+            
+            const bot2Task = taskQueue.enqueue(async () => {
+                await new Promise(resolve => setTimeout(resolve, 50));
+                return 'bot2';
+            }, 'bot-2');
+            
+            const stats = taskQueue.getStats();
+            expect(stats.activeBots).toBeGreaterThan(0);
+            
+            await Promise.all([bot1Task, bot2Task]);
+        });
+
+        it('should wait for all tasks of a specific bot to complete', async () => {
+            let task1Done = false;
+            let task2Done = false;
+            let task3Done = false;
+            
+            // Start tasks for bot-1
+            taskQueue.enqueue(async () => {
+                await new Promise(resolve => setTimeout(resolve, 100));
+                task1Done = true;
+            }, 'bot-1');
+            
+            taskQueue.enqueue(async () => {
+                await new Promise(resolve => setTimeout(resolve, 150));
+                task2Done = true;
+            }, 'bot-1');
+            
+            // Start task for bot-2 (should not affect bot-1 wait)
+            taskQueue.enqueue(async () => {
+                await new Promise(resolve => setTimeout(resolve, 200));
+                task3Done = true;
+            }, 'bot-2');
+            
+            await taskQueue.waitForCompletion('bot-1');
+            
+            expect(task1Done).toBe(true);
+            expect(task2Done).toBe(true);
+            expect(task3Done).toBe(false);
+        });
+
+        it('should resolve immediately if no tasks are active for bot', async () => {
+            const startTime = Date.now();
+            await taskQueue.waitForCompletion('non-existent-bot');
+            const endTime = Date.now();
+            
+            expect(endTime - startTime).toBeLessThan(50);
+        });
+
+        it('should handle multiple waiters for the same bot', async () => {
+            let taskDone = false;
+            
+            taskQueue.enqueue(async () => {
+                await new Promise(resolve => setTimeout(resolve, 100));
+                taskDone = true;
+            }, 'bot-1');
+            
+            const waiter1 = taskQueue.waitForCompletion('bot-1');
+            const waiter2 = taskQueue.waitForCompletion('bot-1');
+            const waiter3 = taskQueue.waitForCompletion('bot-1');
+            
+            await Promise.all([waiter1, waiter2, waiter3]);
+            
+            expect(taskDone).toBe(true);
+        });
+    });
+
+    describe('global queue with per-bot fairness', () => {
+        it('should process tasks globally in FIFO order regardless of bot', async () => {
+            const executionOrder: string[] = [];
+            
+            const singleQueue = new TaskQueue(1);
+            
+            const tasks = [
+                singleQueue.enqueue(async () => {
+                    executionOrder.push('bot1-task1');
+                }, 'bot-1'),
+                singleQueue.enqueue(async () => {
+                    executionOrder.push('bot2-task1');
+                }, 'bot-2'),
+                singleQueue.enqueue(async () => {
+                    executionOrder.push('bot1-task2');
+                }, 'bot-1'),
+                singleQueue.enqueue(async () => {
+                    executionOrder.push('bot3-task1');
+                }, 'bot-3'),
+            ];
+            
+            await Promise.all(tasks);
+            
+            expect(executionOrder).toEqual([
+                'bot1-task1',
+                'bot2-task1',
+                'bot1-task2',
+                'bot3-task1',
+            ]);
+        });
+
+        it('should allow parallel execution across different bots', async () => {
+            let bot1Running = false;
+            let bot2Running = false;
+            let bothRanSimultaneously = false;
+            
+            const task1 = taskQueue.enqueue(async () => {
+                bot1Running = true;
+                await new Promise(resolve => setTimeout(resolve, 100));
+                if (bot2Running) {
+                    bothRanSimultaneously = true;
+                }
+                bot1Running = false;
+            }, 'bot-1');
+            
+            const task2 = taskQueue.enqueue(async () => {
+                bot2Running = true;
+                await new Promise(resolve => setTimeout(resolve, 100));
+                if (bot1Running) {
+                    bothRanSimultaneously = true;
+                }
+                bot2Running = false;
+            }, 'bot-2');
+            
+            await Promise.all([task1, task2]);
+            
+            expect(bothRanSimultaneously).toBe(true);
+        });
+    });
+
+    describe('queue statistics', () => {
+        it('should provide accurate queue statistics', async () => {
+            let stats = taskQueue.getStats();
+            expect(stats.queueLength).toBe(0);
+            expect(stats.availablePermits).toBe(2);
+            
+            const task1 = taskQueue.enqueue(async () => {
+                await new Promise(resolve => setTimeout(resolve, 100));
+            }, 'bot-1');
+            
+            const task2 = taskQueue.enqueue(async () => {
+                await new Promise(resolve => setTimeout(resolve, 100));
+            }, 'bot-2');
+            
+            const task3 = taskQueue.enqueue(async () => {
+                await new Promise(resolve => setTimeout(resolve, 100));
+            }, 'bot-3');
+            
+            await new Promise(resolve => setTimeout(resolve, 10));
+            
+            stats = taskQueue.getStats();
+            expect(stats.activeBots).toBeGreaterThan(0);
+            
+            await Promise.all([task1, task2, task3]);
+            
+            stats = taskQueue.getStats();
+            expect(stats.activeBots).toBe(0);
+        });
+    });
+
+    describe('error handling', () => {
+        it('should continue processing other tasks after one fails', async () => {
+            let task1Done = false;
+            let task3Done = false;
+            
+            const task1 = taskQueue.enqueue(async () => {
+                task1Done = true;
+            });
+            
+            const task2 = taskQueue.enqueue(async () => {
+                throw new Error('Task 2 failed');
+            });
+            
+            const task3 = taskQueue.enqueue(async () => {
+                task3Done = true;
+            });
+            
+            await task1;
+            await expect(task2).rejects.toThrow('Task 2 failed');
+            await task3;
+            
+            expect(task1Done).toBe(true);
+            expect(task3Done).toBe(true);
+        });
+
+        it('should release semaphore permit even when task fails', async () => {
+            const initialPermits = taskQueue.getStats().availablePermits;
+            
+            await expect(
+                taskQueue.enqueue(async () => {
+                    throw new Error('Task failed');
+                })
+            ).rejects.toThrow('Task failed');
+            
+            await new Promise(resolve => setTimeout(resolve, 10));
+            
+            const finalPermits = taskQueue.getStats().availablePermits;
+            expect(finalPermits).toBe(initialPermits);
+        });
+
+        it('should clean up bot tracking when task fails', async () => {
+            await expect(
+                taskQueue.enqueue(async () => {
+                    throw new Error('Bot task failed');
+                }, 'bot-1')
+            ).rejects.toThrow('Bot task failed');
+            
+            await new Promise(resolve => setTimeout(resolve, 10));
+            
+            const stats = taskQueue.getStats();
+            expect(stats.activeBots).toBe(0);
+        });
+    });
+
+    describe('concurrent operations', () => {
+        it('should handle rapid task enqueueing', async () => {
+            const taskCount = 100;
+            let completedCount = 0;
+            
+            const tasks = Array.from({ length: taskCount }, (_, i) =>
+                taskQueue.enqueue(async () => {
+                    completedCount++;
+                    return i;
+                })
+            );
+            
+            const results = await Promise.all(tasks);
+            
+            expect(completedCount).toBe(taskCount);
+            expect(results).toHaveLength(taskCount);
+        });
+
+        it('should handle interleaved enqueue and waitForCompletion calls', async () => {
+            let tasksCompleted = 0;
+            
+            taskQueue.enqueue(async () => {
+                await new Promise(resolve => setTimeout(resolve, 50));
+                tasksCompleted++;
+            }, 'bot-1');
+            
+            taskQueue.enqueue(async () => {
+                await new Promise(resolve => setTimeout(resolve, 100));
+                tasksCompleted++;
+            }, 'bot-1');
+            
+            const waitPromise = taskQueue.waitForCompletion('bot-1');
+            
+            taskQueue.enqueue(async () => {
+                await new Promise(resolve => setTimeout(resolve, 50));
+                tasksCompleted++;
+            }, 'bot-2');
+            
+            await waitPromise;
+            
+            expect(tasksCompleted).toBe(2);
+        });
+    });
+});

--- a/runbotics/runbotics-scheduler/src/utils/task-queue.ts
+++ b/runbotics/runbotics-scheduler/src/utils/task-queue.ts
@@ -1,0 +1,128 @@
+import { Semaphore } from './semaphore';
+
+interface Task<T> {
+    id: string;
+    botId?: string;
+    execute: () => Promise<T>;
+    resolve: (value: T) => void;
+    reject: (error: unknown) => void;
+}
+
+export class TaskQueue {
+    private semaphore: Semaphore;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    private queue: Task<any>[] = [];
+    private processing = false;
+    private taskCounter = 0;
+    private activeTasks = new Map<string, number>();
+    private completionCallbacks = new Map<string, Array<() => void>>();
+
+    constructor(maxParallelism: number) {
+        this.semaphore = new Semaphore(maxParallelism);
+    }
+
+    enqueue<T>(task: () => Promise<T>, botId?: string): Promise<T> {
+        return new Promise<T>((resolve, reject) => {
+            const taskId = `task-${++this.taskCounter}`;
+            
+            this.queue.push({
+                id: taskId,
+                botId,
+                execute: task,
+                resolve,
+                reject,
+            });
+
+            if (botId) {
+                const currentCount = this.activeTasks.get(botId) || 0;
+                this.activeTasks.set(botId, currentCount + 1);
+            }
+
+            this.processQueue();
+        });
+    }
+
+    async waitForCompletion(botId: string): Promise<void> {
+        const taskCount = this.activeTasks.get(botId);
+        if (!taskCount || taskCount === 0) {
+            return;
+        }
+        
+        return new Promise<void>((resolve) => {
+            if (!this.completionCallbacks.has(botId)) {
+                this.completionCallbacks.set(botId, []);
+            }
+            const callbacks = this.completionCallbacks.get(botId);
+            if (callbacks) {
+                callbacks.push(resolve);
+            }
+        });
+    }
+
+    setMaxParallelism(maxParallelism: number): void {
+        this.semaphore.setMaxPermits(maxParallelism);
+        this.processQueue();
+    }
+
+    getStats() {
+        return {
+            queueLength: this.queue.length,
+            availablePermits: this.semaphore.available(),
+            waitingForPermits: this.semaphore.waitingCount(),
+            activeBots: this.activeTasks.size,
+        };
+    }
+
+    private async processQueue(): Promise<void> {
+        if (this.processing) {
+            return;
+        }
+
+        this.processing = true;
+
+        while (this.queue.length > 0) {
+            const task = this.queue.shift();
+            
+            if (!task) {
+                break;
+            }
+            
+            await this.semaphore.acquire();
+            
+            this.executeTask(task);
+        }
+
+        this.processing = false;
+    }
+
+    private async executeTask<T>(task: Task<T>): Promise<void> {
+        try {
+            const result = await task.execute();
+            task.resolve(result);
+        } catch (error) {
+            task.reject(error);
+        } finally {
+            if (task.botId) {
+                const currentCount = this.activeTasks.get(task.botId) || 0;
+                const newCount = currentCount - 1;
+                
+                if (newCount <= 0) {
+                    this.activeTasks.delete(task.botId);
+                    this.notifyBotCompletion(task.botId);
+                } else {
+                    this.activeTasks.set(task.botId, newCount);
+                }
+            }
+            
+            this.semaphore.release();
+        }
+    }
+
+    private notifyBotCompletion(botId: string): void {
+        const callbacks = this.completionCallbacks.get(botId);
+        if (callbacks) {
+            callbacks.forEach(callback => callback());
+            this.completionCallbacks.delete(botId);
+        }
+    }
+}


### PR DESCRIPTION
Now messages are queued on scheduler side, rather than being processed all at once, which greatly decreases amount of memory that is required for allocating things like temp. variables for postgresql operations.

<!--- Provide a general summary of your changes in the Title above (if possible start with issue number with # prefix) -->
<!--- Example: #123 - Some description -->

## Description

<!--- Describe your changes in detail, provide screenshots if necessary -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

---

I agree to the terms of the RunBotics Contributor License Agreement.